### PR TITLE
use an ip filter based on a sorted vector

### DIFF
--- a/ntp-daemon/src/ipfilter.rs
+++ b/ntp-daemon/src/ipfilter.rs
@@ -2,236 +2,128 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::config::subnet::IpSubnet;
 
-/// One part of a BitTree
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
-struct TreeNode {
-    // Where in the array the child nodes of this
-    // node are located. A child node is only
-    // generated if the symbol cannot be used to
-    // make a final decision at this level
-    child_offset: u32,
-    inset: u16,
-    outset: u16,
+pub trait IpAddrContains: Ord + Copy + std::fmt::Debug {
+    fn contains(haystack_ip: Self, haystack_mask: u8, needle_ip: Self) -> bool;
+}
+
+impl IpAddrContains for Ipv4Addr {
+    fn contains(haystack_ip: Self, haystack_mask: u8, needle_ip: Self) -> bool {
+        let shifted = |ip: Self| {
+            u32::from_be_bytes(ip.octets())
+                .checked_shr(32 - haystack_mask as u32)
+                .unwrap_or(0)
+        };
+
+        shifted(haystack_ip) == shifted(needle_ip)
+    }
+}
+
+impl IpAddrContains for Ipv6Addr {
+    fn contains(haystack_ip: Self, haystack_mask: u8, needle_ip: Self) -> bool {
+        let shifted = |ip: Self| {
+            u128::from_be_bytes(ip.octets())
+                .checked_shr(128 - haystack_mask as u32)
+                .unwrap_or(0)
+        };
+
+        shifted(haystack_ip) == shifted(needle_ip)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// BitTree is a Trie on 128 bit integers encoding
-/// which integers are part of the set.
-///
-/// It matches the integer a 4-bit segment at a time
-/// recording at each level whether for a given symbol
-/// all integers with the prefix extended with that
-/// symbol are either in or outside of the set.
-struct BitTree {
-    nodes: Vec<TreeNode>,
+pub struct VecIpFilter<T>(Vec<(T, u8)>);
+
+impl<T> Default for VecIpFilter<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
 }
 
-fn top_nibble(v: u128) -> u8 {
-    ((v >> 124) & 0xF) as u8
-}
+impl<IP: IpAddrContains> VecIpFilter<IP> {
+    fn insert(&mut self, new_ip: IP, new_mask: u8) {
+        let mut already_covered = false;
+        self.0.retain(|(old_ip, old_mask)| {
+            // don't add new if already covered by old
+            if IP::contains(*old_ip, *old_mask, new_ip) {
+                already_covered = true;
+            }
 
-impl BitTree {
-    #[allow(dead_code)]
-    /// Lookup whether a given value is in the set encoded in this BitTree
-    /// Complexity is O(log(l)), where l is the length of the longest
-    /// prefix in the set.
-    fn lookup(&self, mut val: u128) -> bool {
-        let mut node = &self.nodes[0];
-        loop {
-            // extract the current symbol as bit and see if we know the answer immediately.
-            // (example: symbol 1 maps to 0x2, symbol 5 maps to 0x10)
-            let cur = 1 << top_nibble(val);
-            if node.inset & cur != 0 {
-                return true;
-            }
-            if node.outset & cur != 0 {
-                return false;
-            }
-            // no decision, shift to next symbol
-            val <<= 4;
-            // To calculate the child index we need to know how many symbols smaller
-            // than our symbol are not decided here. We do this by generating the bitmap
-            // of symbols neither in in or out, then masking out all symbols >=cur
-            // and finaly counting how many are left.
-            let next_idx =
-                node.child_offset + (!(node.inset | node.outset) & (cur - 1)).count_ones();
-            node = &self.nodes[next_idx as usize];
+            // retain old if not covered by the new mask
+            !IP::contains(new_ip, new_mask, *old_ip)
+        });
+
+        if !already_covered {
+            self.0.push((new_ip, new_mask));
         }
+
+        // sort from biggest to smallest
+        self.0.sort_by(|a, b| b.cmp(a))
     }
 
-    #[allow(dead_code)]
-    /// Create a BitTree from the given prefixes. Complexity is O(n*log(l)),
-    /// where n is the number of prefixes, and l the length of the longest
-    /// prefix.
-    fn create(data: &mut [(u128, u8)]) -> Self {
-        // Ensure values only have 1s in significant positions
-        for (val, len) in data.iter_mut() {
-            *val &= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u128
-                .checked_shl((128 - *len) as u32)
-                .unwrap_or(0);
-        }
-        // Ensure values are sorted by value and then by length
-        data.sort();
-
-        let mut result = BitTree {
-            nodes: vec![TreeNode::default()],
-        };
-        result.fill_node(data, 0);
-        result
-    }
-
-    /// Create the substructure for a node, recursively.
-    /// Max recursion depth is maximum value of data[i].1/4
-    /// for any i
-    fn fill_node(&mut self, mut data: &mut [(u128, u8)], node_idx: usize) {
-        // Figure out how the data splits over the 16 segments
-        // in this node. Note that we can do this in a linear
-        // scan since everything is already sorted.
-        let mut first_idx = [data.len(); 16];
-        first_idx[0] = 0;
-        let mut last = 0;
-        for (idx, (val, _)) in data.iter().enumerate() {
-            let cur = top_nibble(*val);
-            if cur != last {
-                for i in last + 1..=cur {
-                    first_idx[i as usize] = idx
-                }
-                last = cur;
+    fn lookup(&self, needle_ip: &IP) -> bool {
+        // exploit that we've sorted from biggest to smallest;
+        match self.0.iter().find(|(k, _)| k <= needle_ip) {
+            None => false,
+            Some((haystack_ip, haystack_mask)) => {
+                IP::contains(*haystack_ip, *haystack_mask, *needle_ip)
             }
-        }
-
-        // Actually split into the relevant subsegments
-        let mut segs = <[&mut [(u128, u8)]; 16]>::default();
-        for i in 0..15 {
-            (segs[i], data) = data.split_at_mut(first_idx[i + 1] - first_idx[i]);
-        }
-        segs[15] = data;
-
-        // Fill in node
-        let mut child_offset = self.nodes.len();
-        let node = &mut self.nodes[node_idx];
-        node.child_offset = child_offset as u32;
-        for (i, seg) in segs.iter().enumerate() {
-            match seg.first() {
-                // Probably empty, unless covered earlier, but we fix that later
-                None => node.outset |= 1 << i,
-                // Definetly covered, mark all that is needed
-                // Note that due to sorting order, len here
-                // is guaranteed to be largest amongst all
-                // parts of the segment
-                Some((_, len)) if *len <= 4 => {
-                    // mark ALL parts of node covered by the segment as in the set.
-                    for j in 0..(1 << (4 - *len)) {
-                        node.inset |= 1 << (i + j as usize)
-                    }
-                }
-                // May be covered by a the union of all its parts, we need to check
-                // for that. Otherwise it is undecided
-                _ => {
-                    let offset = (i as u128) << 124;
-                    let mut last = 0;
-                    for part in seg.iter() {
-                        if part.0 - offset <= last {
-                            last =
-                                std::cmp::max(last, part.0 - offset + (1_u128 << (128 - part.1)));
-                        }
-                    }
-                    if last >= (1 << 124) {
-                        // All parts together cover the segment, so mark as in
-                        node.inset |= 1 << i;
-                    }
-                }
-            }
-        }
-        // compensate for incorrectly marked outsets due to overcoverage
-        node.outset &= !node.inset;
-
-        let known_bitmap = node.inset | node.outset;
-        // allocate nodes
-        self.nodes.resize(
-            self.nodes.len() + (!known_bitmap).count_ones() as usize,
-            TreeNode::default(),
-        );
-        // Create children for segments undecided at this level.
-        for (i, seg) in segs.iter_mut().enumerate() {
-            if known_bitmap & (1 << i) != 0 {
-                continue; // no child needed
-            }
-            for (val, len) in seg.iter_mut() {
-                *val <<= 4;
-                *len -= 4;
-            }
-            self.fill_node(seg, child_offset);
-            child_offset += 1;
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IpFilter {
-    ipv4_filter: BitTree,
-    ipv6_filter: BitTree,
+    ipv4_filter: VecIpFilter<Ipv4Addr>,
+    ipv6_filter: VecIpFilter<Ipv6Addr>,
 }
 
 impl IpFilter {
     /// Create a filter from a list of subnets
     /// Complexity: O(n) with n length of list
     pub fn new(subnets: &[IpSubnet]) -> Self {
-        let mut ipv4list = Vec::new();
-        let mut ipv6list = Vec::new();
+        let mut ipv4_filter = VecIpFilter::default();
+        let mut ipv6_filter = VecIpFilter::default();
 
         for subnet in subnets {
             match subnet.addr {
-                IpAddr::V4(addr) => ipv4list.push((
-                    (u32::from_be_bytes(addr.octets()) as u128) << 96,
-                    subnet.mask,
-                )),
-                IpAddr::V6(addr) => {
-                    ipv6list.push((u128::from_be_bytes(addr.octets()), subnet.mask))
-                }
+                IpAddr::V4(addr) => ipv4_filter.insert(addr, subnet.mask),
+                IpAddr::V6(addr) => ipv6_filter.insert(addr, subnet.mask),
             }
         }
 
         IpFilter {
-            ipv4_filter: BitTree::create(ipv4list.as_mut_slice()),
-            ipv6_filter: BitTree::create(ipv6list.as_mut_slice()),
+            ipv4_filter,
+            ipv6_filter,
         }
     }
 
     pub fn all() -> Self {
-        let mut temp_v4 = [(0, 0)];
-        let mut temp_v6 = [(0, 0)];
-        IpFilter {
-            ipv4_filter: BitTree::create(&mut temp_v4),
-            ipv6_filter: BitTree::create(&mut temp_v6),
-        }
+        Self::new(&[
+            IpSubnet {
+                addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
+                mask: 32,
+            },
+            IpSubnet {
+                addr: IpAddr::V6(Ipv6Addr::LOCALHOST),
+                mask: 128,
+            },
+        ])
     }
 
     pub fn none() -> Self {
-        let mut temp_v4 = [];
-        let mut temp_v6 = [];
         IpFilter {
-            ipv4_filter: BitTree::create(&mut temp_v4),
-            ipv6_filter: BitTree::create(&mut temp_v6),
+            ipv4_filter: Default::default(),
+            ipv6_filter: Default::default(),
         }
     }
 
     /// Check whether a given ip address is contained in the filter.
-    /// Complexity: O(1)
+    /// Complexity: O(n), but easy to vectorize
     pub fn is_in(&self, addr: &IpAddr) -> bool {
         match addr {
-            IpAddr::V4(addr) => self.is_in4(addr),
-            IpAddr::V6(addr) => self.is_in6(addr),
+            IpAddr::V4(addr) => self.ipv4_filter.lookup(addr),
+            IpAddr::V6(addr) => self.ipv6_filter.lookup(addr),
         }
-    }
-
-    fn is_in4(&self, addr: &Ipv4Addr) -> bool {
-        self.ipv4_filter
-            .lookup((u32::from_be_bytes(addr.octets()) as u128) << 96)
-    }
-
-    fn is_in6(&self, addr: &Ipv6Addr) -> bool {
-        self.ipv6_filter.lookup(u128::from_be_bytes(addr.octets()))
     }
 }
 
@@ -282,25 +174,6 @@ pub mod fuzz {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_bittree() {
-        let mut data = [
-            (0x10 << 120, 4),
-            (0x20 << 120, 3),
-            (0x43 << 120, 8),
-            (0x82 << 120, 7),
-        ];
-        let tree = BitTree::create(&mut data);
-        assert!(tree.lookup(0x11 << 120));
-        assert!(!tree.lookup(0x40 << 120));
-        assert!(tree.lookup(0x30 << 120));
-        assert!(tree.lookup(0x43 << 120));
-        assert!(!tree.lookup(0xC4 << 120));
-        assert!(tree.lookup(0x82 << 120));
-        assert!(tree.lookup(0x83 << 120));
-        assert!(!tree.lookup(0x81 << 120));
-    }
 
     #[test]
     fn test_filter() {


### PR DESCRIPTION
so that we can properly contrast the approaches: an implementation of an ip filter using a sorted vector.

The `BTreeMap` provides sorted keys, but we don't really get any other benefit, and assume that storing the values in a `Vec` will be better versus a tree (e.g. scanning can be vectorized and data locality is better)

This implementation is much smaller than the bitset implementation, and has very little complex logic (some bit shifts, that's it really). A clear win.

But, the time complexity of a lookup (the important operation here, construction is performed once and hence I don't think its complexity is relevant) degrades from `O(1)` to `O(n)`, where `n` is the number of IPs in the filter. That is unfortunate, but

- we expect `n` to be small (couple dozen, at most)
- the implementation can be readily vectorized
- technically we can get it down to `O(log n)` by using a binary search instead of a linear scan. But I predict this is actually slower for small n

So overall I'm in favor of this simpler, `Vec`-based approach