### PR TITLE
remove webpki as a dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ prometheus-client = "0.19.0"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.2"
 rustls-native-certs = "0.6.2"
-webpki = "0.22.0"
 
 # crypto
 aead = "0.5.1"

--- a/test-binaries/Cargo.toml
+++ b/test-binaries/Cargo.toml
@@ -29,4 +29,3 @@ aes-siv.workspace = true
 rustls.workspace = true
 rustls-native-certs.workspace = true
 rustls-pemfile.workspace = true
-webpki.workspace = true


### PR DESCRIPTION
it is still used by rustls at the moment, but they will switch over to their fork (that is maintained and has some security/bug fixes). By upgrading rustls when it is released we should get this updated version of webpki automatically.