### PR TITLE
stop using an extra epoll to await the error queue

### DIFF
--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -288,10 +288,10 @@ where
                     }
                 };
                 // Unwrap should be safe because we know the socket was bound to a local addres just before
-                let our_id = ReferenceId::from_ip(socket.as_ref().local_addr().unwrap().ip());
+                let our_id = ReferenceId::from_ip(socket.local_addr().unwrap().ip());
 
                 // Unwrap should be safe because we know the socket was connected to a remote peer just before
-                let peer_id = ReferenceId::from_ip(socket.as_ref().peer_addr().unwrap().ip());
+                let peer_id = ReferenceId::from_ip(socket.peer_addr().unwrap().ip());
 
                 let local_clock_time = NtpInstant::now();
                 let config_snapshot = *channels.system_config_receiver.borrow_and_update();
@@ -533,8 +533,8 @@ mod tests {
         )
         .await
         .unwrap();
-        let our_id = ReferenceId::from_ip(socket.as_ref().local_addr().unwrap().ip());
-        let peer_id = ReferenceId::from_ip(socket.as_ref().peer_addr().unwrap().ip());
+        let our_id = ReferenceId::from_ip(socket.local_addr().unwrap().ip());
+        let peer_id = ReferenceId::from_ip(socket.peer_addr().unwrap().ip());
 
         let (_, system_snapshot_receiver) = tokio::sync::watch::channel(SystemSnapshot::default());
         let (_, mut system_config_receiver) =


### PR DESCRIPTION
remove the exceptional condition file descriptor, which we used to listen to EPOLLPRI events on the UDP socket, to await when send timestamps are available in the error queue.

I'm removing this because that does not work in the way that we thought. Here is an example program that uses `mio` (which is used by `tokio`, which we use) to send something on a UDP socket with timestamping enabled.

This gives the following output

```
// Poll::new()
epoll_create1(EPOLL_CLOEXEC)            = 3
// UdpSocket::bind 
socket(AF_INET, SOCK_DGRAM|SOCK_CLOEXEC|SOCK_NONBLOCK, IPPROTO_IP) = 4
bind(4, {sa_family=AF_INET, sin_port=htons(8012), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
// UdpSocket::connect
connect(4, {sa_family=AF_INET, sin_port=htons(8013), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
// setsockopt configuring timestamping
setsockopt(4, SOL_SOCKET, SO_TIMESTAMPING_OLD, [2178], 4) = 0
// poll.registry().register
epoll_ctl(3, EPOLL_CTL_ADD, 4, {EPOLLPRI|EPOLLET, {u32=0, u64=0}}) = 0
// socket.send
sendto(4, "abcde", 5, MSG_NOSIGNAL, NULL, 0) = 5
// poll.poll 
epoll_wait(3, [{EPOLLERR, {u32=0, u64=0}}], 1, -1) = 1
```

So, we configure epoll to wait for `EPOLLPRI|EPOLLET` on our UDP socket (fd 4), but the actual event that happens is `EPOLLERR`, not `EPOLLPRI`. This is the event that we actually saw happen, and that triggered the exceptional condition fd. This event always happens when the socket is done with sending, it's not influenced by having timestamping enabled.

Since version 0.7.1, `mio` reports `EPOLLERR` as a `WriteClosed` 

> Report `epoll(2)`'s `EPOLLERR` event as `Event::is_write_closed` if it's the
>  only event
>  (https://github.com/tokio-rs/mio/commit/0c77b5712d675eeb9bd43928b5dd7d22b2c7ac0c).

Furthermore, the `UdpSocket::writable` method will await this event. In practice, by the time we get to the check whether the UDP socket is writable again, that flag is already set and no waiting happens.

All in all that means that the extra fd is not needed, we can, with current tokio, just observe the udp socket until it becomes writable again.