### PR TITLE
Add three new fuzz harness targets to ntp-proto

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -59,3 +59,21 @@ name = "record_encode_decode"
 path = "fuzz_targets/record_encode_decode.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "ntsrecord"
+path = "fuzz_targets/ntsrecord.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "key_exchange_result_decoder"
+path = "fuzz_targets/key_exchange_result_decoder.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "key_exchange_server_decoder"
+path = "fuzz_targets/key_exchange_server_decoder.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/key_exchange_result_decoder.rs
+++ b/fuzz/fuzz_targets/key_exchange_result_decoder.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use ntp_proto::fuzz_key_exchange_result_decoder;
+
+fuzz_target!(|data: &[u8]| {
+    fuzz_key_exchange_result_decoder(data);
+});

--- a/fuzz/fuzz_targets/key_exchange_server_decoder.rs
+++ b/fuzz/fuzz_targets/key_exchange_server_decoder.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use ntp_proto::fuzz_key_exchange_server_decoder;
+
+fuzz_target!(|data: &[u8]| {
+    fuzz_key_exchange_server_decoder(data);
+});

--- a/fuzz/fuzz_targets/ntsrecord.rs
+++ b/fuzz/fuzz_targets/ntsrecord.rs
@@ -1,0 +1,20 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use ntp_proto::NtsRecord;
+
+fuzz_target!(|data: &[u8]| {
+    let mut decoder = NtsRecord::decoder();
+    decoder.extend(data.iter().copied());
+
+    // mimic test_decode_nts_time_nl_response() which has 11 steps
+    let _ = decoder.step();
+    let _ = decoder.step();
+    let _ = decoder.step();
+    let _ = decoder.step();
+    let _ = decoder.step();
+    let _ = decoder.step();
+    let _ = decoder.step();
+    let _ = decoder.step();
+    let _ = decoder.step();
+    let _ = decoder.step();
+});

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -42,6 +42,10 @@ pub use time_types::{
     FrequencyTolerance, NtpDuration, NtpInstant, NtpTimestamp, PollInterval, PollIntervalLimits,
 };
 
+#[cfg(feature = "fuzz")]
+pub use nts_record::fuzz_key_exchange_result_decoder;
+#[cfg(feature = "fuzz")]
+pub use nts_record::fuzz_key_exchange_server_decoder;
 pub use nts_record::{
     KeyExchangeClient, KeyExchangeError, KeyExchangeResult, KeyExchangeServer, NtsRecord,
     NtsRecordDecoder, WriteError,


### PR DESCRIPTION
Add fuzzing logic to exercise `NtsRecord::decoder()`, `KeyExchangeServerDecoder` and `KeyExchangeResultDecoder`.

This is part of the NLnet-sponsored NGI program security review by [Radically Open Security](https://www.radicallyopensecurity.com/). 