### PR TITLE
Provide musl libc compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,6 @@ jobs:
           - 1.65.0
         target:
           - ""
-          - x86_64-unknown-linux-musl
         os: [ubuntu-latest]
         features:
           - ""
@@ -54,6 +53,39 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
+
+  build-musl:
+    name: Build+test-musl
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - 1.65.0
+        target:
+          - "x86_64-unknown-linux-musl"
+        os: [ubuntu-latest]
+        features:
+          - ""
+          - "--features sentry"
+          - "--features rfc-algorithm"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          persist-credentials: false
+      - name: Install ${{ matrix.rust }} toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: cargo build
+        run: cargo build ${{ matrix.features }}
+      - name: cargo test
+        run: cargo test
+        env:
+          RUST_BACKTRACE: 1
 
   unused:
     name: Unused dependencies
@@ -187,6 +219,40 @@ jobs:
         with:
           command: clippy
           args: --target armv7-unknown-linux-gnueabihf --workspace --all-targets -- -D warnings
+
+  clippy-musl:
+    name: ClippyMusl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: stable
+          override: true
+          default: true
+          components: clippy
+          target: x86_64-unknown-linux-musl
+      # Use zig as our C compiler for convenient cross-compilation. We run into rustls having a dependency on `ring`.
+      # This crate uses C and assembly code, and because of its build scripts, `cargo clippy` needs to be able to compile
+      # that code for our target.
+      - uses: goto-bus-stop/setup-zig@869a4299cf8ac7db4ebffaec36ad82a682f88acb
+        with:
+          version: 0.9.0
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@f0b89cda51dc27169e64a0dbc20182a1ec84d8ff
+        with:
+          tool: cargo-zigbuild
+      - name: Run clippy
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
+        env:
+          TARGET_CC: "/home/runner/.cargo/bin/cargo-zigbuild zig cc -- -target x86_64-linux-musl"
+        with:
+          command: clippy
+          args: --target x86_64-unknown-linux-musl --workspace --all-targets -- -D warnings
 
   fuzz:
     name: Smoke-test fuzzing targets

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,9 @@ jobs:
           - stable
           - beta
           - 1.65.0
+        target:
+          - ""
+          - x86_64-unknown-linux-musl
         os: [ubuntu-latest]
         features:
           - ""

--- a/ntp-daemon/src/spawn/standard.rs
+++ b/ntp-daemon/src/spawn/standard.rs
@@ -273,7 +273,10 @@ mod tests {
                 || addr2 != orig_addr
                 || addr3 != orig_addr
                 || addr4 != orig_addr
-                || addr5 != orig_addr
+                || addr5 != orig_addr,
+            "{:?} should not be in {:?}",
+            orig_addr,
+            [addr1, addr2, addr3, addr4, addr5],
         );
     }
 

--- a/ntp-os-clock/src/unix.rs
+++ b/ntp-os-clock/src/unix.rs
@@ -15,7 +15,7 @@ use ntp_proto::{NtpClock, NtpDuration, NtpLeapIndicator, NtpTimestamp, PollInter
 
 // Libc has no good other way of obtaining this, so let's at least make our functions
 // more readable.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub(crate) const EMPTY_TIMEX: libc::timex = libc::timex {
     modes: 0,
     offset: 0,
@@ -51,6 +51,34 @@ pub(crate) const EMPTY_TIMEX: libc::timex = libc::timex {
     __unused9: 0,
     __unused10: 0,
     __unused11: 0,
+};
+
+#[cfg(all(target_os = "linux", target_env = "musl"))]
+pub(crate) const EMPTY_TIMEX: libc::timex = libc::timex {
+    modes: 0,
+    offset: 0,
+    freq: 0,
+    maxerror: 0,
+    esterror: 0,
+    status: 0,
+    constant: 0,
+    precision: 0,
+    tolerance: 0,
+    time: libc::timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    },
+    tick: 0,
+    ppsfreq: 0,
+    jitter: 0,
+    shift: 0,
+    stabil: 0,
+    jitcnt: 0,
+    calcnt: 0,
+    errcnt: 0,
+    stbcnt: 0,
+    tai: 0,
+    __padding: [0; 11]
 };
 
 #[cfg(any(target_os = "freebsd", target_os = "macos"))]

--- a/ntp-os-clock/src/unix.rs
+++ b/ntp-os-clock/src/unix.rs
@@ -213,7 +213,11 @@ impl UnixNtpClock {
         // information in the return value of ntp_adjtime can be ignored.
         // The ntp_adjtime call is safe because the reference always
         // points to a valid libc::timex.
-        if unsafe { libc::ntp_adjtime(timex) } == -1 {
+        #[cfg(any(target_os = "freebsd", target_os = "macos", target_env = "gnu"))]
+        let errno = unsafe { libc::ntp_adjtime(timex) };
+        #[cfg(all(target_os = "linux", target_env = "musl"))]
+        let errno = unsafe { libc::adjtimex(timex) };
+        if errno == -1 {
             Err(convert_errno())
         } else {
             Ok(())

--- a/ntp-os-clock/src/unix.rs
+++ b/ntp-os-clock/src/unix.rs
@@ -78,7 +78,7 @@ pub(crate) const EMPTY_TIMEX: libc::timex = libc::timex {
     errcnt: 0,
     stbcnt: 0,
     tai: 0,
-    __padding: [0; 11]
+    __padding: [0; 11],
 };
 
 #[cfg(any(target_os = "freebsd", target_os = "macos"))]
@@ -209,15 +209,20 @@ impl UnixNtpClock {
     }
 
     fn ntp_adjtime(timex: &mut libc::timex) -> Result<(), Error> {
+        #[cfg(any(target_os = "freebsd", target_os = "macos", target_env = "gnu"))]
+        use libc::ntp_adjtime as adjtime;
+
+        // ntp_adjtime is equivalent to adjtimex for our purposes
+        //
+        // https://man7.org/linux/man-pages/man2/adjtimex.2.html
+        #[cfg(all(target_os = "linux", target_env = "musl"))]
+        use libc::adjtimex as adjtime;
+
         // We don't care about the time status, so the non-error
         // information in the return value of ntp_adjtime can be ignored.
         // The ntp_adjtime call is safe because the reference always
         // points to a valid libc::timex.
-        #[cfg(any(target_os = "freebsd", target_os = "macos", target_env = "gnu"))]
-        let errno = unsafe { libc::ntp_adjtime(timex) };
-        #[cfg(all(target_os = "linux", target_env = "musl"))]
-        let errno = unsafe { libc::adjtimex(timex) };
-        if errno == -1 {
+        if unsafe { adjtime(timex) } == -1 {
             Err(convert_errno())
         } else {
             Ok(())
@@ -238,7 +243,15 @@ impl UnixNtpClock {
 
         let mut timespec = self.clock_gettime()?;
 
-        timespec.tv_sec += offset_secs as libc::time_t;
+        timespec.tv_sec += {
+            // this looks a little strange. it is to work around the `libc::time_t` type being
+            // deprectated for musl in rust's libc.
+            if true {
+                offset_secs as _
+            } else {
+                timespec.tv_sec
+            }
+        };
         timespec.tv_nsec += offset_nanos as libc::c_long;
 
         self.clock_settime(timespec)?;
@@ -253,7 +266,7 @@ impl UnixNtpClock {
         let mut timex = libc::timex {
             modes: libc::ADJ_SETOFFSET | libc::MOD_NANO,
             time: libc::timeval {
-                tv_sec: secs as libc::time_t,
+                tv_sec: secs as _,
                 tv_usec: nanos as libc::suseconds_t,
             },
             ..crate::unix::EMPTY_TIMEX

--- a/ntp-udp/src/hwtimestamp.rs
+++ b/ntp-udp/src/hwtimestamp.rs
@@ -28,7 +28,7 @@ fn set_hardware_timestamp(
     };
 
     let fd = udp_socket.as_raw_fd();
-    cerr(unsafe { libc::ioctl(fd, libc::SIOCSHWTSTAMP as libc::c_ulong, &mut ifreq) })?;
+    cerr(unsafe { libc::ioctl(fd, libc::SIOCSHWTSTAMP as _, &mut ifreq) })?;
 
     Ok(())
 }
@@ -51,7 +51,7 @@ fn get_hardware_timestamp(
     };
 
     let fd = udp_socket.as_raw_fd();
-    cerr(unsafe { libc::ioctl(fd, libc::SIOCGHWTSTAMP as libc::c_ulong, &mut ifreq) })?;
+    cerr(unsafe { libc::ioctl(fd, libc::SIOCGHWTSTAMP as _, &mut ifreq) })?;
 
     Ok(tstamp_config)
 }

--- a/ntp-udp/src/raw_socket.rs
+++ b/ntp-udp/src/raw_socket.rs
@@ -163,7 +163,7 @@ mod set_timestamping_options {
 }
 
 mod recv_message {
-    use std::{io::IoSliceMut, marker::PhantomData, net::SocketAddr, os::unix::prelude::AsRawFd};
+    use std::{io::IoSliceMut, marker::PhantomData, mem::MaybeUninit, net::SocketAddr, os::unix::prelude::AsRawFd, ptr::addr_of_mut};
 
     use tracing::warn;
 
@@ -190,14 +190,31 @@ mod recv_message {
         let mut buf_slice = IoSliceMut::new(packet_buf);
         let mut addr = zeroed_sockaddr_storage();
 
-        let mut mhdr = libc::msghdr {
-            msg_control: control_buf.as_mut_ptr().cast::<libc::c_void>(),
-            msg_controllen: control_buf.len() as _,
-            msg_iov: (&mut buf_slice as *mut IoSliceMut).cast::<libc::iovec>(),
-            msg_iovlen: 1,
-            msg_flags: 0,
-            msg_name: (&mut addr as *mut libc::sockaddr_storage).cast::<libc::c_void>(),
-            msg_namelen: std::mem::size_of::<libc::sockaddr_storage>() as u32,
+        let msg_iov = (&mut buf_slice as *mut IoSliceMut).cast::<libc::iovec>();
+        let msg_name = (&mut addr as *mut libc::sockaddr_storage).cast::<libc::c_void>();
+        let msg_control = control_buf.as_mut_ptr().cast::<libc::c_void>();
+        let mut mhdr = {
+            // Safety:
+            // To initialize private padding fields (present on `target_env = "musl"`), we must use unsafe.
+            let mut mhdr = MaybeUninit::<libc::msghdr>::zeroed();
+            let msg_controllen = control_buf.len() as _;
+            let ptr_msg_control = unsafe { addr_of_mut!((*mhdr.as_mut_ptr()).msg_control) };
+            unsafe {ptr_msg_control.write(msg_control); }
+            let ptr_msg_controllen = unsafe { addr_of_mut!((*mhdr.as_mut_ptr()).msg_controllen) };
+            unsafe { ptr_msg_controllen.write(msg_controllen); }
+            let ptr_msg_iov = unsafe { addr_of_mut!((*mhdr.as_mut_ptr()).msg_iov) };
+            unsafe { ptr_msg_iov.write(msg_iov); }
+            let ptr_msg_iovlen = unsafe { addr_of_mut!((*mhdr.as_mut_ptr()).msg_iovlen) };
+            unsafe { ptr_msg_iovlen.write(1); }
+            let ptr_msg_flags = unsafe { addr_of_mut!((*mhdr.as_mut_ptr()).msg_flags) };
+            unsafe { ptr_msg_flags.write(0); }
+            let ptr_msg_name = unsafe { addr_of_mut!((*mhdr.as_mut_ptr()).msg_name) };
+            unsafe {  ptr_msg_name.write(msg_name); }
+            let ptr_msg_namelen = unsafe { addr_of_mut!((*mhdr.as_mut_ptr()).msg_namelen) };
+            unsafe {
+              ptr_msg_namelen.write(std::mem::size_of::<libc::sockaddr_storage>() as u32);
+              mhdr.assume_init()
+            }
         };
 
         let receive_flags = match queue {

--- a/ntp-udp/src/raw_socket.rs
+++ b/ntp-udp/src/raw_socket.rs
@@ -439,8 +439,8 @@ pub(crate) mod timestamping_config {
                 },
             };
 
-            const SIOCETHTOOL: u64 = 0x8946;
-            cerr(unsafe { libc::ioctl(fd, SIOCETHTOOL as libc::c_ulong, &ifr) }).unwrap();
+            // SIOCETHTOOL = 0x8946 (Ethtool interface) Linux ioctl request
+            cerr(unsafe { libc::ioctl(fd, 0x8946, &ifr) }).unwrap();
 
             let support = EnableTimestamps {
                 rx_software: tsi.so_timestamping & libc::SOF_TIMESTAMPING_RX_SOFTWARE != 0,


### PR DESCRIPTION
Musl libc is a popular alternative to glibc. It was designed for [simplicity, correctness and efficiency](https://musl.libc.org/about.html). It has some slight [incompatibilities with glibc](https://wiki.musl-libc.org/compatibility.html).

Musl libc is [used by](https://wiki.musl-libc.org/projects-using-musl.html) e.g., Alpine Linux and Gentoo as overlay. Alpine Linux is a popular OS for container images.

This change also allows for compilation to statically linked binaries.