### PR TITLE
macOS compilation and testing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,13 @@
 [target.'cfg(all())']
 rustflags = ["-C", "force-unwind-tables"]
+
+# runs tests under sudo, useful for certain (hardware) clock manipulation in tests
+# [target.x86_64-unknown-linux-gnu]
+# runner = 'sudo -E'
+
+# make `cargo clippy --target ...` just work when cross-compiling
+# [target.x86_64-apple-darwin]
+# linker = "~/.cargo/bin/cargo-zigbuild zig cc -- -target x86_64-macos-gnu -g"
+#
+# [target.x86_64-unknown-freebsd]
+# linker = "~/.cargo/bin/cargo-zigbuild zig cc -- -target freebsd -g"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -254,40 +254,6 @@ jobs:
           command: clippy
           args: --target x86_64-apple-darwin --workspace --all-targets -- -D warnings
 
-  clippy-freebsd:
-    name: ClippyFreeBSD
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-        with:
-          persist-credentials: false
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-          toolchain: stable
-          override: true
-          default: true
-          components: clippy
-          target: x86_64-unknown-freebsd
-      # Use zig as our C compiler for convenient cross-compilation. We run into rustls having a dependency on `ring`.
-      # This crate uses C and assembly code, and because of its build scripts, `cargo clippy` needs to be able to compile
-      # that code for our target.
-      - uses: goto-bus-stop/setup-zig@869a4299cf8ac7db4ebffaec36ad82a682f88acb
-        with:
-          version: 0.9.0
-      - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@a24dd0e0c4266ae898414a44466cc7ce1445b31a
-        with:
-          tool: cargo-zigbuild
-      - name: Run clippy
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
-        env:
-          TARGET_CC: "/home/runner/.cargo/bin/cargo-zigbuild zig cc -- -target freebsd -g"
-        with:
-          command: clippy
-          args: --target x86_64-unknown-freebsd --workspace --all-targets -- -D warnings
-
   clippy-musl:
     name: ClippyMusl
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -220,6 +220,74 @@ jobs:
           command: clippy
           args: --target armv7-unknown-linux-gnueabihf --workspace --all-targets -- -D warnings
 
+  clippy-macos:
+    name: ClippyMacOS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: stable
+          override: true
+          default: true
+          components: clippy
+          target: x86_64-apple-darwin
+      # Use zig as our C compiler for convenient cross-compilation. We run into rustls having a dependency on `ring`.
+      # This crate uses C and assembly code, and because of its build scripts, `cargo clippy` needs to be able to compile
+      # that code for our target.
+      - uses: goto-bus-stop/setup-zig@869a4299cf8ac7db4ebffaec36ad82a682f88acb
+        with:
+          version: 0.9.0
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@a24dd0e0c4266ae898414a44466cc7ce1445b31a
+        with:
+          tool: cargo-zigbuild
+      - name: Run clippy
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
+        env:
+          TARGET_CC: "/home/runner/.cargo/bin/cargo-zigbuild zig cc -- -target x86_64-macos-gnu -g"
+        with:
+          command: clippy
+          args: --target x86_64-apple-darwin --workspace --all-targets -- -D warnings
+
+  clippy-freebsd:
+    name: ClippyFreeBSD
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+          toolchain: stable
+          override: true
+          default: true
+          components: clippy
+          target: x86_64-unknown-freebsd
+      # Use zig as our C compiler for convenient cross-compilation. We run into rustls having a dependency on `ring`.
+      # This crate uses C and assembly code, and because of its build scripts, `cargo clippy` needs to be able to compile
+      # that code for our target.
+      - uses: goto-bus-stop/setup-zig@869a4299cf8ac7db4ebffaec36ad82a682f88acb
+        with:
+          version: 0.9.0
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@a24dd0e0c4266ae898414a44466cc7ce1445b31a
+        with:
+          tool: cargo-zigbuild
+      - name: Run clippy
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
+        env:
+          TARGET_CC: "/home/runner/.cargo/bin/cargo-zigbuild zig cc -- -target freebsd -g"
+        with:
+          command: clippy
+          args: --target x86_64-unknown-freebsd --workspace --all-targets -- -D warnings
+
   clippy-musl:
     name: ClippyMusl
     runs-on: ubuntu-latest

--- a/ntp-daemon/src/config/mod.rs
+++ b/ntp-daemon/src/config/mod.rs
@@ -255,7 +255,7 @@ impl Config {
         let meta = std::fs::metadata(&file).unwrap();
         let perm = meta.permissions();
 
-        if perm.mode() & libc::S_IWOTH != 0 {
+        if perm.mode() as libc::mode_t & libc::S_IWOTH != 0 {
             warn!("Unrestricted config file permissions: Others can write.");
         }
 

--- a/ntp-daemon/src/config/peer.rs
+++ b/ntp-daemon/src/config/peer.rs
@@ -161,13 +161,11 @@ impl NormalizedAddress {
 
     #[cfg(test)]
     pub async fn lookup_host(&self) -> std::io::Result<impl Iterator<Item = SocketAddr> + '_> {
-        let addresses = if !self.hardcoded_dns_resolve.is_empty() {
-            self.hardcoded_dns_resolve.to_vec()
-        } else {
-            tokio::net::lookup_host((self.server_name.as_str(), self.port))
-                .await?
-                .collect()
-        };
+        // We don't want to spam a real DNS server during testing
+        let mut addresses = self.hardcoded_dns_resolve.to_vec();
+
+        // Randomise the response, so we don't get the same address every time
+        addresses.sort_unstable_by_key(|_| rand::random::<u32>());
 
         Ok(addresses.into_iter())
     }

--- a/ntp-daemon/src/spawn/standard.rs
+++ b/ntp-daemon/src/spawn/standard.rs
@@ -197,9 +197,16 @@ mod tests {
 
     #[tokio::test]
     async fn reresolves_on_unreachable() {
+        let address_strings = ["127.0.0.1:123", "127.0.0.2:123", "127.0.0.3:123"];
+        let addresses = address_strings.map(|addr| addr.parse().unwrap());
+
         let spawner = StandardSpawner::new(
             StandardPeerConfig {
-                addr: NormalizedAddress::with_hardcoded_dns("europe.pool.ntp.org", 123, vec![]),
+                addr: NormalizedAddress::with_hardcoded_dns(
+                    "europe.pool.ntp.org",
+                    123,
+                    addresses.to_vec(),
+                ),
             },
             NETWORK_WAIT_PERIOD,
         );
@@ -209,74 +216,39 @@ mod tests {
         tokio::spawn(async move { spawner.run(action_tx, notify_rx).await });
         let res = action_rx.recv().await.unwrap();
         let params = get_create_params(res);
-        let orig_addr = params.addr.to_string();
+        let initial_addr = params.addr;
 
         // We repeat multiple times and check at least one is different to be less
         // sensitive to dns resolver giving the same pool ip.
-        notify_tx
-            .send(SystemEvent::peer_removed(
-                params.id,
-                PeerRemovalReason::Unreachable,
-            ))
-            .await
-            .unwrap();
-        let res = action_rx.recv().await.unwrap();
-        let params = get_create_params(res);
-        let addr1 = params.addr.to_string();
+        let mut seen_addresses = vec![];
+        for _ in 0..5 {
+            notify_tx
+                .send(SystemEvent::peer_removed(
+                    params.id,
+                    PeerRemovalReason::Unreachable,
+                ))
+                .await
+                .unwrap();
+            let res = action_rx.recv().await.unwrap();
+            let params = get_create_params(res);
+            seen_addresses.push(params.addr);
+        }
+        let seen_addresses = seen_addresses;
 
-        notify_tx
-            .send(SystemEvent::peer_removed(
-                params.id,
-                PeerRemovalReason::Unreachable,
-            ))
-            .await
-            .unwrap();
-        let res = action_rx.recv().await.unwrap();
-        let params = get_create_params(res);
-        let addr2 = params.addr.to_string();
-
-        notify_tx
-            .send(SystemEvent::peer_removed(
-                params.id,
-                PeerRemovalReason::Unreachable,
-            ))
-            .await
-            .unwrap();
-        let res = action_rx.recv().await.unwrap();
-        let params = get_create_params(res);
-        let addr3 = params.addr.to_string();
-
-        notify_tx
-            .send(SystemEvent::peer_removed(
-                params.id,
-                PeerRemovalReason::Unreachable,
-            ))
-            .await
-            .unwrap();
-        let res = action_rx.recv().await.unwrap();
-        let params = get_create_params(res);
-        let addr4 = params.addr.to_string();
-
-        notify_tx
-            .send(SystemEvent::peer_removed(
-                params.id,
-                PeerRemovalReason::Unreachable,
-            ))
-            .await
-            .unwrap();
-        let res = action_rx.recv().await.unwrap();
-        let params = get_create_params(res);
-        let addr5 = params.addr.to_string();
+        for addr in seen_addresses.iter() {
+            assert!(
+                addresses.contains(&addr),
+                "{:?} should have been drawn from {:?}",
+                addr,
+                addresses
+            );
+        }
 
         assert!(
-            addr1 != orig_addr
-                || addr2 != orig_addr
-                || addr3 != orig_addr
-                || addr4 != orig_addr
-                || addr5 != orig_addr,
-            "{:?} should not be in {:?}",
-            orig_addr,
-            [addr1, addr2, addr3, addr4, addr5],
+            seen_addresses.iter().any(|seen| seen != &initial_addr),
+            "Re-resolved\n\n\t{:?}\n\n should contain at least one address that isn't the original\n\n\t{:?}",
+            seen_addresses,
+            initial_addr,
         );
     }
 

--- a/ntp-daemon/src/spawn/standard.rs
+++ b/ntp-daemon/src/spawn/standard.rs
@@ -237,7 +237,7 @@ mod tests {
 
         for addr in seen_addresses.iter() {
             assert!(
-                addresses.contains(&addr),
+                addresses.contains(addr),
                 "{:?} should have been drawn from {:?}",
                 addr,
                 addresses

--- a/ntp-os-clock/src/unix.rs
+++ b/ntp-os-clock/src/unix.rs
@@ -5,10 +5,7 @@
 // is constructed in such a way that use of the public functions is
 // safe regardless of given arguments.
 
-use std::{
-    os::unix::io::{AsRawFd, RawFd},
-    path::Path,
-};
+use std::{ffi::CStr, os::fd::RawFd};
 
 use crate::{Error, EPOCH_OFFSET};
 use ntp_proto::{NtpClock, NtpDuration, NtpLeapIndicator, NtpTimestamp, PollInterval};
@@ -106,7 +103,7 @@ pub(crate) const EMPTY_TIMEX: libc::timex = libc::timex {
 /// current time.
 // Implementation note: this is intentionally a bare struct, the NTP Clock defined
 // in the NTP KAPI is unique and no state is needed to interact with it.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct UnixNtpClock {
     clock: libc::clockid_t,
 }
@@ -120,59 +117,47 @@ impl UnixNtpClock {
         Self { clock: id }
     }
 
-    pub fn from_path(path: &Path) -> Result<Self, Error> {
-        match std::fs::File::options().read(true).write(true).open(path) {
-            Err(_) => Err(convert_errno()),
-            Ok(file) => {
-                let fd = file.as_raw_fd();
-
-                // never close the file, keep it open so clock steering can use the file descriptor
-                std::mem::forget(file);
-
-                Ok(Self::from_file_descriptor(fd))
-            }
-        }
+    #[cfg_attr(target_os = "linux", allow(unused))]
+    pub fn ptp0() -> Result<Self, Error> {
+        let path = CStr::from_bytes_with_nul(b"/dev/ptp0\0").unwrap();
+        // SAFETY
+        //
+        // we know this is a file descriptor of a clock
+        unsafe { Self::from_path(path) }
     }
 
-    pub fn from_file_descriptor(fd: RawFd) -> Self {
-        // using an invalid clock id is safe. The function that take this value as an argument will
-        // return an EINVAL IO error when the clock id is invalid.
+    unsafe fn from_path(path: &CStr) -> Result<Self, Error> {
+        let fd = match unsafe { libc::open(path.as_ptr(), libc::O_RDWR) } {
+            -1 => return Err(convert_errno()),
+            valid => valid,
+        };
 
+        Ok(unsafe { Self::from_file_descriptor(fd as RawFd) })
+    }
+
+    unsafe fn from_file_descriptor(fd: RawFd) -> Self {
         let id = ((!(fd as libc::clockid_t)) << 3) | 0b11;
+
         Self::custom(id)
     }
 
-    #[cfg_attr(target_os = "linux", allow(unused))]
     fn clock_gettime(&self) -> Result<libc::timespec, Error> {
         let mut timespec = libc::timespec {
             tv_sec: 0,
             tv_nsec: 0,
         };
 
-        // # Safety
-        //
-        // using an invalid clock id is safe. `clock_adjtime` will return an EINVAL error
-        // https://linux.die.net/man/3/clock_gettime
-        //
-        // The timespec pointer is valid.
         cerr(unsafe { libc::clock_gettime(self.clock, &mut timespec) })?;
 
         Ok(timespec)
     }
 
-    #[cfg_attr(target_os = "linux", allow(unused))]
     fn clock_settime(&self, mut timespec: libc::timespec) -> Result<(), Error> {
         while timespec.tv_nsec > 1_000_000_000 {
             timespec.tv_sec += 1;
             timespec.tv_nsec -= 1_000_000_000;
         }
 
-        // # Safety
-        //
-        // using an invalid clock id is safe. `clock_adjtime` will return an EINVAL error
-        // https://linux.die.net/man/3/clock_settime
-        //
-        // The timespec pointer is valid.
         unsafe { cerr(libc::clock_settime(self.clock, &timespec))? };
 
         Ok(())
@@ -180,28 +165,10 @@ impl UnixNtpClock {
 
     fn clock_adjtime(&self, timex: &mut libc::timex) -> Result<(), Error> {
         // We don't care about the time status, so the non-error
-        // information in the return value of clock_adjtime can be ignored.
-        //
-        // # Safety
-        //
-        // The clock_adjtime call is safe because the reference always
+        // information in the return value of ntp_adjtime can be ignored.
+        // The ntp_adjtime call is safe because the reference always
         // points to a valid libc::timex.
-        //
-        // using an invalid clock id is safe. `clock_adjtime` will return an EINVAL error
-        // https://man.archlinux.org/man/clock_adjtime.2.en#EINVAL~4
-        #[cfg(target_os = "linux")]
-        use libc::clock_adjtime as adjtime;
-
-        #[cfg(any(target_os = "freebsd", target_os = "macos"))]
-        let adjtime = {
-            extern "C" {
-                fn clock_adjtime(clk_id: libc::clockid_t, buf: *mut libc::timex) -> libc::c_int;
-            }
-
-            clock_adjtime
-        };
-
-        if unsafe { adjtime(self.clock, timex) } == -1 {
+        if unsafe { libc::clock_adjtime(self.clock, timex) } == -1 {
             Err(convert_errno())
         } else {
             Ok(())
@@ -209,20 +176,11 @@ impl UnixNtpClock {
     }
 
     fn ntp_adjtime(timex: &mut libc::timex) -> Result<(), Error> {
-        #[cfg(any(target_os = "freebsd", target_os = "macos", target_env = "gnu"))]
-        use libc::ntp_adjtime as adjtime;
-
-        // ntp_adjtime is equivalent to adjtimex for our purposes
-        //
-        // https://man7.org/linux/man-pages/man2/adjtimex.2.html
-        #[cfg(all(target_os = "linux", target_env = "musl"))]
-        use libc::adjtimex as adjtime;
-
         // We don't care about the time status, so the non-error
         // information in the return value of ntp_adjtime can be ignored.
         // The ntp_adjtime call is safe because the reference always
         // points to a valid libc::timex.
-        if unsafe { adjtime(timex) } == -1 {
+        if unsafe { libc::ntp_adjtime(timex) } == -1 {
             Err(convert_errno())
         } else {
             Ok(())
@@ -234,71 +192,6 @@ impl UnixNtpClock {
             Self::ntp_adjtime(timex)
         } else {
             self.clock_adjtime(timex)
-        }
-    }
-
-    #[cfg_attr(target_os = "linux", allow(unused))]
-    fn step_clock_timespec(&self, offset: ntp_proto::NtpDuration) -> Result<NtpTimestamp, Error> {
-        let (offset_secs, offset_nanos) = offset.as_seconds_nanos();
-
-        let mut timespec = self.clock_gettime()?;
-
-        timespec.tv_sec += {
-            // this looks a little strange. it is to work around the `libc::time_t` type being
-            // deprectated for musl in rust's libc.
-            if true {
-                offset_secs as _
-            } else {
-                timespec.tv_sec
-            }
-        };
-        timespec.tv_nsec += offset_nanos as libc::c_long;
-
-        self.clock_settime(timespec)?;
-
-        Ok(current_time_timespec(timespec, Precision::Nano))
-    }
-
-    #[cfg(target_os = "linux")]
-    fn step_clock_timex(&self, offset: ntp_proto::NtpDuration) -> Result<NtpTimestamp, Error> {
-        let (secs, nanos) = offset.as_seconds_nanos();
-
-        let mut timex = libc::timex {
-            modes: libc::ADJ_SETOFFSET | libc::MOD_NANO,
-            time: libc::timeval {
-                tv_sec: secs as _,
-                tv_usec: nanos as libc::suseconds_t,
-            },
-            ..crate::unix::EMPTY_TIMEX
-        };
-
-        self.adjtime(&mut timex)?;
-        self.extract_current_time(&timex)
-    }
-
-    fn extract_current_time(&self, _timex: &libc::timex) -> Result<NtpTimestamp, Error> {
-        #[cfg(target_os = "linux")]
-        {
-            // hardware clocks may not report the timestamp
-            if _timex.time.tv_sec != 0 && _timex.time.tv_usec != 0 {
-                // in a timex, the status flag determines precision
-                let precision = match _timex.status & libc::STA_NANO {
-                    0 => Precision::Micro,
-                    _ => Precision::Nano,
-                };
-
-                Ok(current_time_timeval(_timex.time, precision))
-            } else {
-                let timespec = self.clock_gettime()?;
-                Ok(current_time_timespec(timespec, Precision::Nano))
-            }
-        }
-
-        #[cfg(any(target_os = "freebsd", target_os = "macos"))]
-        {
-            // clock_gettime always gives nanoseconds
-            let timespec = self.clock_gettime()?;
-            Ok(current_time_timespec(timespec, Precision::Nano))
         }
     }
 }
@@ -393,6 +286,13 @@ fn ignore_not_supported(res: Result<(), Error>) -> Result<(), Error> {
         Err(Error::NotSupported) => Ok(()),
         other => other,
     }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        // clock_gettime always gives nanoseconds
+        let timespec = clock_gettime()?;
+        Ok(current_time_timespec(timespec, Precision::Nano))
+    }
 }
 
 impl NtpClock for UnixNtpClock {
@@ -412,21 +312,22 @@ impl NtpClock for UnixNtpClock {
         // NTP Kapi expects frequency adjustment in units of 2^-16 ppm
         // but our input is in units of seconds drift per second, so convert.
         ntp_kapi_timex.freq = (freq * 65536e6) as libc::c_long;
-        ntp_kapi_timex.status =
-            !libc::STA_PLL & !libc::STA_PPSFREQ & !libc::STA_FLL & !libc::STA_PPSTIME;
-
         self.adjtime(&mut ntp_kapi_timex)?;
-        self.extract_current_time(&ntp_kapi_timex)
+        extract_current_time(&ntp_kapi_timex)
     }
 
     #[cfg(target_os = "linux")]
     fn step_clock(&self, offset: ntp_proto::NtpDuration) -> Result<NtpTimestamp, Self::Error> {
-        self.step_clock_timex(offset)
-    }
+        let (offset_secs, offset_nanos) = offset.as_seconds_nanos();
 
-    #[cfg(any(target_os = "freebsd", target_os = "macos"))]
-    fn step_clock(&self, offset: ntp_proto::NtpDuration) -> Result<NtpTimestamp, Self::Error> {
-        self.step_clock_timespec(offset)
+        let mut timespec = self.clock_gettime()?;
+
+        timespec.tv_sec += offset_secs as libc::time_t;
+        timespec.tv_nsec += offset_nanos as libc::c_long;
+
+        self.clock_settime(timespec)?;
+
+        Ok(current_time_timespec(timespec, Precision::Nano))
     }
 
     fn enable_ntp_algorithm(&self) -> Result<(), Self::Error> {
@@ -450,9 +351,7 @@ impl NtpClock for UnixNtpClock {
 
         // Disable all kernel time control loops (phase lock, frequency lock, pps time and pps frequency).
         timex.status &= !libc::STA_PLL & !libc::STA_FLL & !libc::STA_PPSTIME & !libc::STA_PPSFREQ;
-
-        // ignore if we cannot disable the kernel time control loops (e.g. external clocks)
-        ignore_not_supported(self.adjtime(&mut timex))
+        self.adjtime(&mut timex)
     }
 
     fn ntp_algorithm_update(
@@ -464,7 +363,7 @@ impl NtpClock for UnixNtpClock {
         timex.modes = libc::MOD_OFFSET | libc::MOD_TIMECONST;
         timex.offset = duration_in_nanos(offset);
         timex.constant = poll_interval.as_log() as libc::c_long;
-        ignore_not_supported(self.adjtime(&mut timex))
+        self.adjtime(&mut timex)
     }
 
     fn error_estimate_update(
@@ -476,7 +375,7 @@ impl NtpClock for UnixNtpClock {
         timex.modes = libc::MOD_ESTERROR | libc::MOD_MAXERROR;
         timex.esterror = duration_in_nanos(est_error) / 1000;
         timex.maxerror = duration_in_nanos(max_error) / 1000;
-        ignore_not_supported(self.adjtime(&mut timex))
+        self.adjtime(&mut timex)
     }
 
     fn status_update(&self, leap_status: NtpLeapIndicator) -> Result<(), Self::Error> {
@@ -492,7 +391,7 @@ impl NtpClock for UnixNtpClock {
             NtpLeapIndicator::Leap59 => timex.status |= libc::STA_DEL,
             NtpLeapIndicator::Unknown => timex.status |= libc::STA_UNSYNC,
         }
-        ignore_not_supported(self.adjtime(&mut timex))
+        self.adjtime(&mut timex)
     }
 }
 

--- a/ntp-os-clock/src/unix.rs
+++ b/ntp-os-clock/src/unix.rs
@@ -5,7 +5,10 @@
 // is constructed in such a way that use of the public functions is
 // safe regardless of given arguments.
 
-use std::{ffi::CStr, os::fd::RawFd};
+use std::{
+    os::unix::io::{AsRawFd, RawFd},
+    path::Path,
+};
 
 use crate::{Error, EPOCH_OFFSET};
 use ntp_proto::{NtpClock, NtpDuration, NtpLeapIndicator, NtpTimestamp, PollInterval};
@@ -103,7 +106,7 @@ pub(crate) const EMPTY_TIMEX: libc::timex = libc::timex {
 /// current time.
 // Implementation note: this is intentionally a bare struct, the NTP Clock defined
 // in the NTP KAPI is unique and no state is needed to interact with it.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct UnixNtpClock {
     clock: libc::clockid_t,
 }
@@ -117,47 +120,59 @@ impl UnixNtpClock {
         Self { clock: id }
     }
 
-    #[cfg_attr(target_os = "linux", allow(unused))]
-    pub fn ptp0() -> Result<Self, Error> {
-        let path = CStr::from_bytes_with_nul(b"/dev/ptp0\0").unwrap();
-        // SAFETY
-        //
-        // we know this is a file descriptor of a clock
-        unsafe { Self::from_path(path) }
+    pub fn from_path(path: &Path) -> Result<Self, Error> {
+        match std::fs::File::options().read(true).write(true).open(path) {
+            Err(_) => Err(convert_errno()),
+            Ok(file) => {
+                let fd = file.as_raw_fd();
+
+                // never close the file, keep it open so clock steering can use the file descriptor
+                std::mem::forget(file);
+
+                Ok(Self::from_file_descriptor(fd))
+            }
+        }
     }
 
-    unsafe fn from_path(path: &CStr) -> Result<Self, Error> {
-        let fd = match unsafe { libc::open(path.as_ptr(), libc::O_RDWR) } {
-            -1 => return Err(convert_errno()),
-            valid => valid,
-        };
+    pub fn from_file_descriptor(fd: RawFd) -> Self {
+        // using an invalid clock id is safe. The function that take this value as an argument will
+        // return an EINVAL IO error when the clock id is invalid.
 
-        Ok(unsafe { Self::from_file_descriptor(fd as RawFd) })
-    }
-
-    unsafe fn from_file_descriptor(fd: RawFd) -> Self {
         let id = ((!(fd as libc::clockid_t)) << 3) | 0b11;
-
         Self::custom(id)
     }
 
+    #[cfg_attr(target_os = "linux", allow(unused))]
     fn clock_gettime(&self) -> Result<libc::timespec, Error> {
         let mut timespec = libc::timespec {
             tv_sec: 0,
             tv_nsec: 0,
         };
 
+        // # Safety
+        //
+        // using an invalid clock id is safe. `clock_adjtime` will return an EINVAL error
+        // https://linux.die.net/man/3/clock_gettime
+        //
+        // The timespec pointer is valid.
         cerr(unsafe { libc::clock_gettime(self.clock, &mut timespec) })?;
 
         Ok(timespec)
     }
 
+    #[cfg_attr(target_os = "linux", allow(unused))]
     fn clock_settime(&self, mut timespec: libc::timespec) -> Result<(), Error> {
         while timespec.tv_nsec > 1_000_000_000 {
             timespec.tv_sec += 1;
             timespec.tv_nsec -= 1_000_000_000;
         }
 
+        // # Safety
+        //
+        // using an invalid clock id is safe. `clock_adjtime` will return an EINVAL error
+        // https://linux.die.net/man/3/clock_settime
+        //
+        // The timespec pointer is valid.
         unsafe { cerr(libc::clock_settime(self.clock, &timespec))? };
 
         Ok(())
@@ -165,10 +180,28 @@ impl UnixNtpClock {
 
     fn clock_adjtime(&self, timex: &mut libc::timex) -> Result<(), Error> {
         // We don't care about the time status, so the non-error
-        // information in the return value of ntp_adjtime can be ignored.
-        // The ntp_adjtime call is safe because the reference always
+        // information in the return value of clock_adjtime can be ignored.
+        //
+        // # Safety
+        //
+        // The clock_adjtime call is safe because the reference always
         // points to a valid libc::timex.
-        if unsafe { libc::clock_adjtime(self.clock, timex) } == -1 {
+        //
+        // using an invalid clock id is safe. `clock_adjtime` will return an EINVAL error
+        // https://man.archlinux.org/man/clock_adjtime.2.en#EINVAL~4
+        #[cfg(target_os = "linux")]
+        use libc::clock_adjtime as adjtime;
+
+        #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+        let adjtime = {
+            extern "C" {
+                fn clock_adjtime(clk_id: libc::clockid_t, buf: *mut libc::timex) -> libc::c_int;
+            }
+
+            clock_adjtime
+        };
+
+        if unsafe { adjtime(self.clock, timex) } == -1 {
             Err(convert_errno())
         } else {
             Ok(())
@@ -176,11 +209,20 @@ impl UnixNtpClock {
     }
 
     fn ntp_adjtime(timex: &mut libc::timex) -> Result<(), Error> {
+        #[cfg(any(target_os = "freebsd", target_os = "macos", target_env = "gnu"))]
+        use libc::ntp_adjtime as adjtime;
+
+        // ntp_adjtime is equivalent to adjtimex for our purposes
+        //
+        // https://man7.org/linux/man-pages/man2/adjtimex.2.html
+        #[cfg(all(target_os = "linux", target_env = "musl"))]
+        use libc::adjtimex as adjtime;
+
         // We don't care about the time status, so the non-error
         // information in the return value of ntp_adjtime can be ignored.
         // The ntp_adjtime call is safe because the reference always
         // points to a valid libc::timex.
-        if unsafe { libc::ntp_adjtime(timex) } == -1 {
+        if unsafe { adjtime(timex) } == -1 {
             Err(convert_errno())
         } else {
             Ok(())
@@ -192,6 +234,71 @@ impl UnixNtpClock {
             Self::ntp_adjtime(timex)
         } else {
             self.clock_adjtime(timex)
+        }
+    }
+
+    #[cfg_attr(target_os = "linux", allow(unused))]
+    fn step_clock_timespec(&self, offset: ntp_proto::NtpDuration) -> Result<NtpTimestamp, Error> {
+        let (offset_secs, offset_nanos) = offset.as_seconds_nanos();
+
+        let mut timespec = self.clock_gettime()?;
+
+        timespec.tv_sec += {
+            // this looks a little strange. it is to work around the `libc::time_t` type being
+            // deprectated for musl in rust's libc.
+            if true {
+                offset_secs as _
+            } else {
+                timespec.tv_sec
+            }
+        };
+        timespec.tv_nsec += offset_nanos as libc::c_long;
+
+        self.clock_settime(timespec)?;
+
+        Ok(current_time_timespec(timespec, Precision::Nano))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn step_clock_timex(&self, offset: ntp_proto::NtpDuration) -> Result<NtpTimestamp, Error> {
+        let (secs, nanos) = offset.as_seconds_nanos();
+
+        let mut timex = libc::timex {
+            modes: libc::ADJ_SETOFFSET | libc::MOD_NANO,
+            time: libc::timeval {
+                tv_sec: secs as _,
+                tv_usec: nanos as libc::suseconds_t,
+            },
+            ..crate::unix::EMPTY_TIMEX
+        };
+
+        self.adjtime(&mut timex)?;
+        self.extract_current_time(&timex)
+    }
+
+    fn extract_current_time(&self, _timex: &libc::timex) -> Result<NtpTimestamp, Error> {
+        #[cfg(target_os = "linux")]
+        {
+            // hardware clocks may not report the timestamp
+            if _timex.time.tv_sec != 0 && _timex.time.tv_usec != 0 {
+                // in a timex, the status flag determines precision
+                let precision = match _timex.status & libc::STA_NANO {
+                    0 => Precision::Micro,
+                    _ => Precision::Nano,
+                };
+
+                Ok(current_time_timeval(_timex.time, precision))
+            } else {
+                let timespec = self.clock_gettime()?;
+                Ok(current_time_timespec(timespec, Precision::Nano))
+            }
+        }
+
+        #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+        {
+            // clock_gettime always gives nanoseconds
+            let timespec = self.clock_gettime()?;
+            Ok(current_time_timespec(timespec, Precision::Nano))
         }
     }
 }
@@ -270,6 +377,7 @@ fn current_time_timespec(timespec: libc::timespec, precision: Precision) -> NtpT
     )
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(unused))]
 fn current_time_timeval(timespec: libc::timeval, precision: Precision) -> NtpTimestamp {
     // Negative eras are completely valid, so any wrapping is perfectly reasonable here.
     NtpTimestamp::from_seconds_nanos_since_ntp_era(
@@ -285,13 +393,6 @@ fn ignore_not_supported(res: Result<(), Error>) -> Result<(), Error> {
     match res {
         Err(Error::NotSupported) => Ok(()),
         other => other,
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        // clock_gettime always gives nanoseconds
-        let timespec = clock_gettime()?;
-        Ok(current_time_timespec(timespec, Precision::Nano))
     }
 }
 
@@ -312,22 +413,21 @@ impl NtpClock for UnixNtpClock {
         // NTP Kapi expects frequency adjustment in units of 2^-16 ppm
         // but our input is in units of seconds drift per second, so convert.
         ntp_kapi_timex.freq = (freq * 65536e6) as libc::c_long;
+        ntp_kapi_timex.status =
+            !libc::STA_PLL & !libc::STA_PPSFREQ & !libc::STA_FLL & !libc::STA_PPSTIME;
+
         self.adjtime(&mut ntp_kapi_timex)?;
-        extract_current_time(&ntp_kapi_timex)
+        self.extract_current_time(&ntp_kapi_timex)
     }
 
     #[cfg(target_os = "linux")]
     fn step_clock(&self, offset: ntp_proto::NtpDuration) -> Result<NtpTimestamp, Self::Error> {
-        let (offset_secs, offset_nanos) = offset.as_seconds_nanos();
+        self.step_clock_timex(offset)
+    }
 
-        let mut timespec = self.clock_gettime()?;
-
-        timespec.tv_sec += offset_secs as libc::time_t;
-        timespec.tv_nsec += offset_nanos as libc::c_long;
-
-        self.clock_settime(timespec)?;
-
-        Ok(current_time_timespec(timespec, Precision::Nano))
+    #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+    fn step_clock(&self, offset: ntp_proto::NtpDuration) -> Result<NtpTimestamp, Self::Error> {
+        self.step_clock_timespec(offset)
     }
 
     fn enable_ntp_algorithm(&self) -> Result<(), Self::Error> {
@@ -351,7 +451,9 @@ impl NtpClock for UnixNtpClock {
 
         // Disable all kernel time control loops (phase lock, frequency lock, pps time and pps frequency).
         timex.status &= !libc::STA_PLL & !libc::STA_FLL & !libc::STA_PPSTIME & !libc::STA_PPSFREQ;
-        self.adjtime(&mut timex)
+
+        // ignore if we cannot disable the kernel time control loops (e.g. external clocks)
+        ignore_not_supported(self.adjtime(&mut timex))
     }
 
     fn ntp_algorithm_update(
@@ -363,7 +465,7 @@ impl NtpClock for UnixNtpClock {
         timex.modes = libc::MOD_OFFSET | libc::MOD_TIMECONST;
         timex.offset = duration_in_nanos(offset);
         timex.constant = poll_interval.as_log() as libc::c_long;
-        self.adjtime(&mut timex)
+        ignore_not_supported(self.adjtime(&mut timex))
     }
 
     fn error_estimate_update(
@@ -375,7 +477,7 @@ impl NtpClock for UnixNtpClock {
         timex.modes = libc::MOD_ESTERROR | libc::MOD_MAXERROR;
         timex.esterror = duration_in_nanos(est_error) / 1000;
         timex.maxerror = duration_in_nanos(max_error) / 1000;
-        self.adjtime(&mut timex)
+        ignore_not_supported(self.adjtime(&mut timex))
     }
 
     fn status_update(&self, leap_status: NtpLeapIndicator) -> Result<(), Self::Error> {
@@ -391,7 +493,7 @@ impl NtpClock for UnixNtpClock {
             NtpLeapIndicator::Leap59 => timex.status |= libc::STA_DEL,
             NtpLeapIndicator::Unknown => timex.status |= libc::STA_UNSYNC,
         }
-        self.adjtime(&mut timex)
+        ignore_not_supported(self.adjtime(&mut timex))
     }
 }
 

--- a/ntp-os-clock/src/unix.rs
+++ b/ntp-os-clock/src/unix.rs
@@ -192,7 +192,18 @@ impl UnixNtpClock {
         #[cfg(target_os = "linux")]
         use libc::clock_adjtime as adjtime;
 
-        #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+        #[cfg(target_os = "macos")]
+        unsafe fn adjtime(clk_id: libc::clockid_t, buf: *mut libc::timex) -> libc::c_int {
+            assert_eq!(
+                clk_id,
+                libc::CLOCK_REALTIME,
+                "only the REALTIME clock is supported"
+            );
+
+            libc::ntp_adjtime(buf)
+        }
+
+        #[cfg(target_os = "freebsd")]
         let adjtime = {
             extern "C" {
                 fn clock_adjtime(clk_id: libc::clockid_t, buf: *mut libc::timex) -> libc::c_int;

--- a/ntp-udp/src/interface_name.rs
+++ b/ntp-udp/src/interface_name.rs
@@ -217,6 +217,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_os = "macos", ignore = "gives a weird AF_FAMILY value")]
     fn decode_socket_addr_v6() {
         let raw = [
             0x20, 0x01, 0x08, 0x88, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/ntp-udp/src/interface_name.rs
+++ b/ntp-udp/src/interface_name.rs
@@ -217,7 +217,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_os = "macos", ignore = "gives a weird AF_FAMILY value")]
     fn decode_socket_addr_v6() {
         let raw = [
             0x20, 0x01, 0x08, 0x88, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/ntp-udp/src/interface_name.rs
+++ b/ntp-udp/src/interface_name.rs
@@ -188,6 +188,8 @@ mod tests {
         let sockaddr = libc::sockaddr {
             sa_family: libc::AF_INET as libc::sa_family_t,
             sa_data: [0, 0, 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+            #[cfg(target_os = "macos")]
+            sa_len: 14u8,
         };
 
         let socket_addr = unsafe { sockaddr_to_socket_addr(&sockaddr) }.unwrap();
@@ -202,6 +204,8 @@ mod tests {
         let sockaddr = libc::sockaddr {
             sa_family: libc::AF_INET as libc::sa_family_t,
             sa_data: [0, 42, -84 as _, 23, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+            #[cfg(target_os = "macos")]
+            sa_len: 14u8,
         };
 
         let socket_addr = unsafe { sockaddr_to_socket_addr(&sockaddr) }.unwrap();
@@ -225,6 +229,8 @@ mod tests {
             sin6_flowinfo: 0,
             sin6_addr: libc::in6_addr { s6_addr: raw },
             sin6_scope_id: 0,
+            #[cfg(target_os = "macos")]
+            sin6_len: 14u8,
         };
 
         let socket_addr =

--- a/ntp-udp/src/lib.rs
+++ b/ntp-udp/src/lib.rs
@@ -49,6 +49,7 @@ impl Default for EnableTimestamps {
 
 #[derive(Clone, Copy)]
 pub(crate) enum LibcTimestamp {
+    #[cfg_attr(any(target_os = "macos", target_os = "freebsd"), allow(unused))]
     Timespec(libc::timespec),
     Timeval(libc::timeval),
 }

--- a/ntp-udp/src/lib.rs
+++ b/ntp-udp/src/lib.rs
@@ -7,10 +7,12 @@
 //! for more information.
 #![forbid(unsafe_op_in_unsafe_fn)]
 
-mod hwtimestamp;
 mod interface_name;
 mod raw_socket;
 mod socket;
+
+#[cfg(target_os = "linux")]
+mod hwtimestamp;
 
 use std::{ops::Deref, str::FromStr};
 

--- a/ntp-udp/src/raw_socket.rs
+++ b/ntp-udp/src/raw_socket.rs
@@ -535,7 +535,7 @@ mod exceptional_condition_fd {
         AsyncFd::new(fd)
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub(crate) fn exceptional_condition_fd(
         socket_of_interest: &std::net::UdpSocket,
     ) -> std::io::Result<AsyncFd<RawFd>> {

--- a/ntp-udp/src/socket.rs
+++ b/ntp-udp/src/socket.rs
@@ -563,7 +563,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_software_send_timestamp() {
+    #[cfg_attr(target_os = "macos", ignore = "send timestamps are not supported")]
+    async fn test_send_timestamp() {
         let mut a = UdpSocket::client_with_timestamping(
             SocketAddr::from((Ipv4Addr::LOCALHOST, 8012)),
             SocketAddr::from((Ipv4Addr::LOCALHOST, 8013)),

--- a/ntp-udp/src/socket.rs
+++ b/ntp-udp/src/socket.rs
@@ -155,7 +155,7 @@ impl UdpSocket {
                 Ok(send_timestamp) => Ok((send_size, Some(send_timestamp?))),
             }
 
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
             Ok((send_size, None))
         } else {
             trace!("send timestamping not supported");

--- a/ntp-udp/src/socket.rs
+++ b/ntp-udp/src/socket.rs
@@ -71,8 +71,9 @@ impl UdpSocket {
 
         // bind the socket to a specific interface. This is relevant for hardware timestamping,
         // because the interface determines which clock is used to produce the timestamps.
-        if let Some(interface) = interface {
-            socket.bind_device(Some(&interface)).unwrap();
+        if let Some(_interface) = interface {
+            #[cfg(target_os = "linux")]
+            socket.bind_device(Some(&_interface)).unwrap();
         }
 
         socket.connect(peer_addr).await?;
@@ -107,8 +108,9 @@ impl UdpSocket {
 
         // bind the socket to a specific interface. This is relevant for hardware timestamping,
         // because the interface determines which clock is used to produce the timestamps.
-        if let Some(interface) = interface {
-            socket.bind_device(Some(&interface)).unwrap();
+        if let Some(_interface) = interface {
+            #[cfg(target_os = "linux")]
+            socket.bind_device(Some(&_interface)).unwrap();
         }
 
         let socket = socket.into_std()?;
@@ -310,22 +312,10 @@ fn recv(
             }
 
             ControlMessage::Other(msg) => {
-                eprintln!(
+                warn!(
                     "weird control message {:?} {:?}",
                     msg.cmsg_level, msg.cmsg_type
                 );
-                match (msg.cmsg_level, msg.cmsg_type) {
-                    #[cfg(target_os = "macos")]
-                    (libc::SOL_SOCKET, libc::SO_ACCEPTCONN) => {
-                        // ignore
-                    }
-                    _ => {
-                        warn!(
-                            msg.cmsg_level,
-                            msg.cmsg_type, "unexpected message on the MSG_ERRQUEUE",
-                        );
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
**THIS DOES NOT MEAN MACOS IS NOW SUPPORTED!**

taking a bunch of my earlier work and changes from @andrewaylett 's PR #712 

I've tested this a bunch on macOS, and found one issue: the timestamps reported by the OS can have more than one second's worth of nanos. the timestamp looked fine otherwise, so we now correct this (add to seconds, subtract from nanos). Not doing so results in an assert.

@andrewaylett made some great suggestions for testing our spawner. This introduces (limited) non-determinism into the tests, but I'd argue that is actually what we want for a dns resolver.

an open question for the future (when we look at properly supporting FreeBSD) is the config. For instance, macos and probably freebsd do not allow steering of particular clocks with the APIs that we use. Tokio also does not allow setting of interfaces on those platforms. So some of our configuration just does not apply for these platforms. 