### PR TITLE
Refactor to keep peer packets in peers.

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -308,12 +308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6eee2d5d0d113f015688310da018bd1d864d86bd567c8fca9c266889e1bfa"
-
-[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,12 +327,6 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "exitcode"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "generic-array"
@@ -540,16 +528,14 @@ dependencies = [
 
 [[package]]
 name = "ntp-daemon"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "clap",
- "exitcode",
  "libc",
  "ntp-os-clock",
  "ntp-proto",
  "ntp-udp",
- "prometheus-client",
  "rand",
  "rustls",
  "rustls-native-certs",
@@ -565,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "ntp-os-clock"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "libc",
  "ntp-proto",
@@ -575,12 +561,11 @@ dependencies = [
 
 [[package]]
 name = "ntp-proto"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aead",
  "aes-siv",
  "arbitrary",
- "exitcode",
  "md-5",
  "rand",
  "rustls",
@@ -601,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "ntp-udp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "libc",
  "ntp-proto",
@@ -690,29 +675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.105",
 ]
 
 [[package]]

--- a/ntp-daemon/src/peer.rs
+++ b/ntp-daemon/src/peer.rs
@@ -29,7 +29,6 @@ impl Wait for Sleep {
 }
 
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
 pub enum MsgForSystem {
     /// Received a Kiss-o'-Death and must demobilize
     MustDemobilize(PeerId),

--- a/ntp-daemon/src/system.rs
+++ b/ntp-daemon/src/system.rs
@@ -296,8 +296,8 @@ impl<C: NtpClock, T: Wait> System<C, T> {
             MsgForSystem::MustDemobilize(index) => {
                 self.handle_peer_demobilize(index).await;
             }
-            MsgForSystem::NewMeasurement(index, snapshot, measurement, packet) => {
-                self.handle_peer_measurement(index, snapshot, measurement, packet, wait);
+            MsgForSystem::NewMeasurement(index, snapshot, measurement) => {
+                self.handle_peer_measurement(index, snapshot, measurement, wait);
             }
             MsgForSystem::UpdatedSnapshot(index, snapshot) => {
                 self.handle_peer_snapshot(index, snapshot);
@@ -378,12 +378,11 @@ impl<C: NtpClock, T: Wait> System<C, T> {
         index: PeerId,
         snapshot: PeerSnapshot,
         measurement: ntp_proto::Measurement,
-        packet: ntp_proto::NtpPacket<'static>,
         wait: &mut Pin<&mut SingleshotSleep<T>>,
     ) {
         self.handle_peer_snapshot(index, snapshot);
         // note: local needed for borrow checker
-        let update = self.controller.peer_measurement(index, measurement, packet);
+        let update = self.controller.peer_measurement(index, measurement);
         self.handle_algorithm_state_update(update, wait);
     }
 
@@ -544,7 +543,7 @@ pub struct ServerData {
 mod tests {
     use ntp_proto::{
         peer_snapshot, KeySetProvider, Measurement, NtpDuration, NtpInstant, NtpLeapIndicator,
-        NtpPacket, NtpTimestamp, PollInterval,
+        NtpTimestamp, PollInterval,
     };
 
     use crate::spawn::dummy::DummySpawner;
@@ -651,10 +650,17 @@ mod tests {
                     Measurement {
                         delay: NtpDuration::from_seconds(0.1),
                         offset: NtpDuration::from_seconds(0.),
+                        transmit_timestamp: NtpTimestamp::default(),
+                        receive_timestamp: NtpTimestamp::default(),
                         localtime: NtpTimestamp::from_seconds_nanos_since_ntp_era(0, 0),
                         monotime: base,
+
+                        stratum: 0,
+                        root_delay: NtpDuration::default(),
+                        root_dispersion: NtpDuration::default(),
+                        leap: NtpLeapIndicator::NoWarning,
+                        precision: 0,
                     },
-                    NtpPacket::test(),
                 ),
                 &mut wait,
             )
@@ -680,10 +686,17 @@ mod tests {
                     Measurement {
                         delay: NtpDuration::from_seconds(0.1),
                         offset: NtpDuration::from_seconds(0.),
+                        transmit_timestamp: NtpTimestamp::default(),
+                        receive_timestamp: NtpTimestamp::default(),
                         localtime: NtpTimestamp::from_seconds_nanos_since_ntp_era(0, 0),
                         monotime: base,
+
+                        stratum: 0,
+                        root_delay: NtpDuration::default(),
+                        root_dispersion: NtpDuration::default(),
+                        leap: NtpLeapIndicator::NoWarning,
+                        precision: 0,
                     },
-                    NtpPacket::test(),
                 ),
                 &mut wait,
             )

--- a/ntp-proto/src/algorithm/mod.rs
+++ b/ntp-proto/src/algorithm/mod.rs
@@ -2,9 +2,7 @@ use std::{fmt::Debug, hash::Hash};
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use crate::{
-    peer::Measurement, NtpClock, NtpDuration, NtpPacket, NtpTimestamp, SystemConfig, TimeSnapshot,
-};
+use crate::{peer::Measurement, NtpClock, NtpDuration, NtpTimestamp, SystemConfig, TimeSnapshot};
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct ObservablePeerTimedata {
@@ -58,12 +56,7 @@ pub trait TimeSyncController<C: NtpClock, PeerID: Hash + Eq + Copy + Debug> {
     /// Notify the controller of a new measurement from a peer.
     /// The list of peerIDs is used for loop detection, with the
     /// first peerID given considered the primary peer used.
-    fn peer_measurement(
-        &mut self,
-        id: PeerID,
-        measurement: Measurement,
-        packet: NtpPacket<'static>,
-    ) -> StateUpdate<PeerID>;
+    fn peer_measurement(&mut self, id: PeerID, measurement: Measurement) -> StateUpdate<PeerID>;
     /// Non-measurement driven update (queued via next_update)
     fn time_update(&mut self) -> StateUpdate<PeerID>;
     /// Get a snapshot of the timekeeping state of a peer.

--- a/ntp-proto/src/peer.rs
+++ b/ntp-proto/src/peer.rs
@@ -278,7 +278,6 @@ pub enum AcceptSynchronizationError {
 }
 
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum Update {
     BareUpdate(PeerSnapshot),
     NewMeasurement(PeerSnapshot, Measurement),


### PR DESCRIPTION
The advantage of this is that it reduces the amount of copying of packets that we do in the client, which is unwanted because:
 - it is somewhat expensive (with nts there are multiple layers of allocations that happen when making packet copies)
 - it means some somewhat sensitive values (mainly cookies) end up duplicated in multiple places where they aren't needed.