### PR TITLE
Detect outside meddling with the system clock and deal with it.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -306,6 +306,7 @@ The high performance clock algorithm has quite a few options. Most of these are 
 | delay-outlier-threshold | 5.0 | Threshold (in number of standard deviations) above which measurements with a significantly larger network delay are rejected. (standard deviations, 0+) |
 | initial-wander | 1e-8 | Initial estimate of the clock wander between our local clock and that of the peer. Increasing this results in better synchronization if the hardware matches it, but at the cost of slower synchronization when overly optimistic. (s/s^2) |
 | initial-frequency-uncertainty | 100e-6 | Initial uncertainty of the frequency difference between our clock and that of the peer. Lower values increase the speed of frequency synchronization when correct, but decrease it when overly optimistic. (s/s) |
+| meddling_threshold | 5.0 | Threshold (in seconds) above which unexpected time differences between the monotonic and system clocks trigger a restart of the synchronization process. |
 
 A second set of options control more internal details of how the algorithm estimates its errors and regulates the poll interval. Care should be taken in choosing the values here, and they are primarily provided for easy access when developing the algorithm further:
 | Option | Default | Description |

--- a/ntp-proto/src/algorithm/kalman/config.rs
+++ b/ntp-proto/src/algorithm/kalman/config.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use crate::NtpDuration;
+
 #[derive(Debug, Copy, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct AlgorithmConfig {
@@ -102,6 +104,10 @@ pub struct AlgorithmConfig {
     /// overly conservative root dispersion.
     #[serde(default)]
     pub ignore_server_dispersion: bool,
+
+    /// Threshold for detecting external clock meddling
+    #[serde(default = "default_meddling_threshold")]
+    pub meddling_threshold: NtpDuration,
 }
 
 impl Default for AlgorithmConfig {
@@ -137,6 +143,8 @@ impl Default for AlgorithmConfig {
             max_frequency_steer: default_max_frequency_steer(),
 
             ignore_server_dispersion: false,
+
+            meddling_threshold: default_meddling_threshold(),
         }
     }
 }
@@ -227,4 +235,8 @@ fn default_max_frequency_steer() -> f64 {
 
 fn default_slew_min_duration() -> f64 {
     8.0
+}
+
+fn default_meddling_threshold() -> NtpDuration {
+    NtpDuration::from_seconds(5.)
 }


### PR DESCRIPTION
This patch ensures that any external change to the system clock resets the kalman algorithm, ensuring we at least keep operating when that happens even though it is less than ideal. Depends on #760 

Fixes #717 