### PR TITLE
Clearer panic logic

### DIFF
--- a/ntp-proto/src/packet/extensionfields.rs
+++ b/ntp-proto/src/packet/extensionfields.rs
@@ -485,28 +485,23 @@ impl<'a> RawEncryptedField<'a> {
     ) -> Result<Self, ParsingError<std::convert::Infallible>> {
         use ParsingError::*;
 
-        if message_bytes.len() < 4 {
+        let [ b0, b1, b2, b3, ref rest @ .. ] = message_bytes[..] else {
             return Err(IncorrectLength);
-        }
+        };
 
-        let value = message_bytes;
-
-        if message_bytes.len() < 4 {
-            return Err(IncorrectLength);
-        }
-
-        let nonce_length = u16::from_be_bytes(value[0..2].try_into().unwrap()) as usize;
-        let ciphertext_length = u16::from_be_bytes(value[2..4].try_into().unwrap()) as usize;
+        let nonce_length = u16::from_be_bytes([b0, b1]) as usize;
+        let ciphertext_length = u16::from_be_bytes([b2, b3]) as usize;
 
         if nonce_length != 16 {
             return Err(IncorrectLength);
         }
 
+        let nonce = rest.get(..nonce_length).ok_or(IncorrectLength)?;
+
+        // skip the lengths and the nonce. pad to a multiple of 4
         let ciphertext_start = 4 + next_multiple_of(nonce_length as u16, 4) as usize;
 
-        let nonce = value.get(4..4 + nonce_length).ok_or(IncorrectLength)?;
-
-        let ciphertext = value
+        let ciphertext = message_bytes
             .get(ciphertext_start..ciphertext_start + ciphertext_length)
             .ok_or(IncorrectLength)?;
 

--- a/ntp-proto/src/packet/extensionfields.rs
+++ b/ntp-proto/src/packet/extensionfields.rs
@@ -128,7 +128,7 @@ impl<'a> ExtensionField<'a> {
         let header_width = 4;
 
         let actual_length =
-            next_multiple_of((data_length as u16 + header_width).max(minimum_size), 4);
+            next_multiple_of_u16((data_length as u16 + header_width).max(minimum_size), 4);
         w.write_all(&ef_id.to_type_id().to_be_bytes())?;
         w.write_all(&actual_length.to_be_bytes())
     }
@@ -149,7 +149,7 @@ impl<'a> ExtensionField<'a> {
         let header_width = 4;
 
         let actual_length =
-            next_multiple_of((data_length as u16 + header_width).max(minimum_size), 4);
+            next_multiple_of_u16((data_length as u16 + header_width).max(minimum_size), 4);
 
         Self::write_zeros(w, actual_length - (data_length as u16) - 4)
     }
@@ -277,19 +277,19 @@ impl<'a> ExtensionField<'a> {
 
         // + 8 for the extension field header (4 bytes) and nonce/cypher text length (2 bytes each)
         let signature_octet_count =
-            8 + next_multiple_of((nonce_octet_count + ct_octet_count) as u16, 4);
+            8 + next_multiple_of_u16((nonce_octet_count + ct_octet_count) as u16, 4);
 
         w.write_all(&signature_octet_count.to_be_bytes())?;
         w.write_all(&(nonce_octet_count as u16).to_be_bytes())?;
         w.write_all(&(ct_octet_count as u16).to_be_bytes())?;
 
         w.write_all(&nonce)?;
-        let padding_bytes = next_multiple_of(nonce.len() as u16, 4) - nonce.len() as u16;
+        let padding_bytes = next_multiple_of_u16(nonce.len() as u16, 4) - nonce.len() as u16;
         w.write_all(&padding[..padding_bytes as usize])?;
 
         w.write_all(&siv_tag)?;
         w.write_all(ciphertext)?;
-        let padding_bytes = next_multiple_of(ct_octet_count as u16, 4) - ct_octet_count as u16;
+        let padding_bytes = next_multiple_of_u16(ct_octet_count as u16, 4) - ct_octet_count as u16;
         w.write_all(&padding[..padding_bytes as usize])?;
 
         Ok(())
@@ -505,7 +505,7 @@ impl<'a> RawEncryptedField<'a> {
         let nonce = rest.get(..nonce_length).ok_or(IncorrectLength)?;
 
         // skip the lengths and the nonce. pad to a multiple of 4
-        let ciphertext_start = 4 + next_multiple_of(nonce_length as u16, 4) as usize;
+        let ciphertext_start = 4 + next_multiple_of_u16(nonce_length as u16, 4) as usize;
 
         let ciphertext = message_bytes
             .get(ciphertext_start..ciphertext_start + ciphertext_length)
@@ -557,7 +557,7 @@ impl<'a> RawExtensionField<'a> {
 
     fn wire_length(&self) -> usize {
         // type_id and extension_field_length + data + padding
-        4 + self.message_bytes.len()
+        4 + next_multiple_of_usize(self.message_bytes.len(), 4)
     }
 
     fn deserialize(
@@ -633,7 +633,14 @@ impl<'a> Iterator for ExtensionFieldStreamer<'a> {
     }
 }
 
-const fn next_multiple_of(lhs: u16, rhs: u16) -> u16 {
+const fn next_multiple_of_u16(lhs: u16, rhs: u16) -> u16 {
+    match lhs % rhs {
+        0 => lhs,
+        r => lhs + (rhs - r),
+    }
+}
+
+const fn next_multiple_of_usize(lhs: usize, rhs: usize) -> usize {
     match lhs % rhs {
         0 => lhs,
         r => lhs + (rhs - r),

--- a/ntp-proto/src/packet/extensionfields.rs
+++ b/ntp-proto/src/packet/extensionfields.rs
@@ -360,7 +360,12 @@ pub(super) struct ExtensionFieldData<'a> {
 pub(super) struct DeserializedExtensionField<'a> {
     pub(super) efdata: ExtensionFieldData<'a>,
     pub(super) remaining_bytes: &'a [u8],
-    pub(super) opt_cookie: Option<Option<DecodedServerCookie>>,
+    pub(super) cookie: Option<DecodedServerCookie>,
+}
+
+pub(super) struct InvalidNtsExtensionField<'a> {
+    pub(super) efdata: ExtensionFieldData<'a>,
+    pub(super) remaining_bytes: &'a [u8],
 }
 
 impl<'a> ExtensionFieldData<'a> {
@@ -415,27 +420,31 @@ impl<'a> ExtensionFieldData<'a> {
     pub(super) fn deserialize(
         extension_field_bytes: &'a [u8],
         cipher: &impl CipherProvider,
-    ) -> Result<DeserializedExtensionField<'a>, ParsingError<std::convert::Infallible>> {
-        let mut this = Self::default();
+    ) -> Result<DeserializedExtensionField<'a>, ParsingError<InvalidNtsExtensionField<'a>>> {
+        use ExtensionField::InvalidNtsEncryptedField;
+
+        let mut efdata = Self::default();
         let mut size = 0;
         let mut is_valid_nts = true;
         let mut cookie = None;
+
         for field in RawExtensionField::deserialize_sequence(
             extension_field_bytes,
             Mac::MAXIMUM_SIZE,
             RawExtensionField::V4_UNENCRYPTED_MINIMUM_SIZE,
         ) {
-            let field = field?;
+            let field = field.map_err(|e| e.generalize())?;
             size += field.wire_length();
+
             match field.type_id {
                 ExtensionFieldTypeId::NtsEncryptedField => {
-                    let encrypted = RawEncryptedField::from_message_bytes(field.message_bytes)?;
+                    let encrypted = RawEncryptedField::from_message_bytes(field.message_bytes)
+                        .map_err(|e| e.generalize())?;
 
-                    let cipher = match cipher.get(&this.untrusted) {
+                    let cipher = match cipher.get(&efdata.untrusted) {
                         Some(cipher) => cipher,
                         None => {
-                            this.untrusted
-                                .push(ExtensionField::InvalidNtsEncryptedField);
+                            efdata.untrusted.push(InvalidNtsEncryptedField);
                             is_valid_nts = false;
                             continue;
                         }
@@ -445,34 +454,49 @@ impl<'a> ExtensionFieldData<'a> {
                         match encrypted.decrypt(cipher.as_ref(), field.message_bytes) {
                             Ok(encrypted_fields) => encrypted_fields,
                             Err(e) => {
+                                // early return if it's anything but a decrypt error
                                 e.get_decrypt_error()?;
-                                this.untrusted
-                                    .push(ExtensionField::InvalidNtsEncryptedField);
+
+                                efdata.untrusted.push(InvalidNtsEncryptedField);
                                 is_valid_nts = false;
                                 continue;
                             }
                         };
 
-                    this.encrypted.extend(encrypted_fields.into_iter());
+                    efdata.encrypted.extend(encrypted_fields.into_iter());
                     cookie = match cipher {
                         super::crypto::CipherHolder::DecodedServerCookie(cookie) => Some(cookie),
                         super::crypto::CipherHolder::Other(_) => None,
                     };
 
                     // All previous untrusted fields are now validated
-                    this.authenticated.append(&mut this.untrusted);
+                    efdata.authenticated.append(&mut efdata.untrusted);
                 }
-                _ => this.untrusted.push(ExtensionField::decode(field)?),
+                _ => {
+                    let field = ExtensionField::decode(field).map_err(|e| e.generalize())?;
+                    efdata.untrusted.push(field)
+                }
             }
         }
 
-        let result = DeserializedExtensionField {
-            efdata: this,
-            remaining_bytes: &extension_field_bytes[size..],
-            opt_cookie: is_valid_nts.then_some(cookie),
-        };
+        let remaining_bytes = &extension_field_bytes[size..];
 
-        Ok(result)
+        if is_valid_nts {
+            let result = DeserializedExtensionField {
+                efdata,
+                remaining_bytes,
+                cookie,
+            };
+
+            Ok(result)
+        } else {
+            let result = InvalidNtsExtensionField {
+                efdata,
+                remaining_bytes,
+            };
+
+            Err(ParsingError::DecryptError(result))
+        }
     }
 }
 

--- a/ntp-proto/src/packet/extensionfields.rs
+++ b/ntp-proto/src/packet/extensionfields.rs
@@ -418,26 +418,25 @@ impl<'a> ExtensionFieldData<'a> {
     ) -> Result<DeserializedExtensionField<'a>, ParsingError<std::convert::Infallible>> {
         let mut this = Self::default();
         let mut size = 0;
-        let mut has_invalid_nts = false;
+        let mut is_valid_nts = true;
         let mut cookie = None;
         for field in RawExtensionField::deserialize_sequence(
             &extension_field_bytes,
             Mac::MAXIMUM_SIZE,
             RawExtensionField::V4_UNENCRYPTED_MINIMUM_SIZE,
         ) {
-            let field = field.map_err(|e| e.generalize())?;
+            let field = field?;
             size += field.wire_length();
             match field.type_id {
                 ExtensionFieldTypeId::NtsEncryptedField => {
-                    let encrypted = RawEncryptedField::from_message_bytes(field.message_bytes)
-                        .map_err(|e| e.generalize())?;
+                    let encrypted = RawEncryptedField::from_message_bytes(field.message_bytes)?;
 
                     let cipher = match cipher.get(&this.untrusted) {
                         Some(cipher) => cipher,
                         None => {
                             this.untrusted
                                 .push(ExtensionField::InvalidNtsEncryptedField);
-                            has_invalid_nts = true;
+                            is_valid_nts = false;
                             continue;
                         }
                     };
@@ -449,7 +448,7 @@ impl<'a> ExtensionFieldData<'a> {
                                 e.get_decrypt_error()?;
                                 this.untrusted
                                     .push(ExtensionField::InvalidNtsEncryptedField);
-                                has_invalid_nts = true;
+                                is_valid_nts = false;
                                 continue;
                             }
                         };
@@ -463,16 +462,14 @@ impl<'a> ExtensionFieldData<'a> {
                     // All previous untrusted fields are now validated
                     this.authenticated.append(&mut this.untrusted);
                 }
-                _ => this
-                    .untrusted
-                    .push(ExtensionField::decode(field).map_err(|e| e.generalize())?),
+                _ => this.untrusted.push(ExtensionField::decode(field)?),
             }
         }
 
         let result = DeserializedExtensionField {
             efdata: this,
             remaining_bytes: &extension_field_bytes[size..],
-            opt_cookie: (!has_invalid_nts).then_some(cookie),
+            opt_cookie: is_valid_nts.then_some(cookie),
         };
 
         Ok(result)

--- a/ntp-proto/src/packet/extensionfields.rs
+++ b/ntp-proto/src/packet/extensionfields.rs
@@ -357,6 +357,12 @@ pub(super) struct ExtensionFieldData<'a> {
     pub(super) untrusted: Vec<ExtensionField<'a>>,
 }
 
+pub(super) struct DeserializedExtensionField<'a> {
+    pub(super) efdata: ExtensionFieldData<'a>,
+    pub(super) remaining_bytes: &'a [u8],
+    pub(super) opt_cookie: Option<Option<DecodedServerCookie>>,
+}
+
 impl<'a> ExtensionFieldData<'a> {
     pub(super) fn into_owned(self) -> ExtensionFieldData<'static> {
         let map_into_owned =
@@ -410,10 +416,7 @@ impl<'a> ExtensionFieldData<'a> {
         data: &'a [u8],
         header_size: usize,
         cipher: &impl CipherProvider,
-    ) -> Result<
-        (Self, usize, Option<DecodedServerCookie>),
-        ParsingError<(ExtensionFieldData<'a>, usize)>,
-    > {
+    ) -> Result<DeserializedExtensionField<'a>, ParsingError<std::convert::Infallible>> {
         let mut this = Self::default();
         let mut size = 0;
         let mut has_invalid_nts = false;
@@ -466,11 +469,14 @@ impl<'a> ExtensionFieldData<'a> {
                     .push(ExtensionField::decode(field).map_err(|e| e.generalize())?),
             }
         }
-        if has_invalid_nts {
-            Err(ParsingError::DecryptError((this, size + header_size)))
-        } else {
-            Ok((this, size + header_size, cookie))
-        }
+
+        let result = DeserializedExtensionField {
+            efdata: this,
+            remaining_bytes: &data[header_size + size..],
+            opt_cookie: (!has_invalid_nts).then_some(cookie),
+        };
+
+        Ok(result)
     }
 }
 

--- a/ntp-proto/src/packet/extensionfields.rs
+++ b/ntp-proto/src/packet/extensionfields.rs
@@ -413,8 +413,7 @@ impl<'a> ExtensionFieldData<'a> {
 
     #[allow(clippy::type_complexity)]
     pub(super) fn deserialize(
-        data: &'a [u8],
-        header_size: usize,
+        extension_field_bytes: &'a [u8],
         cipher: &impl CipherProvider,
     ) -> Result<DeserializedExtensionField<'a>, ParsingError<std::convert::Infallible>> {
         let mut this = Self::default();
@@ -422,12 +421,12 @@ impl<'a> ExtensionFieldData<'a> {
         let mut has_invalid_nts = false;
         let mut cookie = None;
         for field in RawExtensionField::deserialize_sequence(
-            &data[header_size..],
+            &extension_field_bytes,
             Mac::MAXIMUM_SIZE,
             RawExtensionField::V4_UNENCRYPTED_MINIMUM_SIZE,
         ) {
-            let (offset, field) = field.map_err(|e| e.generalize())?;
-            size = offset + field.wire_length();
+            let field = field.map_err(|e| e.generalize())?;
+            size += field.wire_length();
             match field.type_id {
                 ExtensionFieldTypeId::NtsEncryptedField => {
                     let encrypted = RawEncryptedField::from_message_bytes(field.message_bytes)
@@ -444,7 +443,7 @@ impl<'a> ExtensionFieldData<'a> {
                     };
 
                     let encrypted_fields =
-                        match encrypted.decrypt(cipher.as_ref(), &data[..header_size + offset]) {
+                        match encrypted.decrypt(cipher.as_ref(), field.message_bytes) {
                             Ok(encrypted_fields) => encrypted_fields,
                             Err(e) => {
                                 e.get_decrypt_error()?;
@@ -472,7 +471,7 @@ impl<'a> ExtensionFieldData<'a> {
 
         let result = DeserializedExtensionField {
             efdata: this,
-            remaining_bytes: &data[header_size + size..],
+            remaining_bytes: &extension_field_bytes[size..],
             opt_cookie: (!has_invalid_nts).then_some(cookie),
         };
 
@@ -530,7 +529,7 @@ impl<'a> RawEncryptedField<'a> {
 
         RawExtensionField::deserialize_sequence(&plaintext, 0, RawExtensionField::BARE_MINIMUM_SIZE)
             .map(|encrypted_field| {
-                let encrypted_field = encrypted_field.map_err(|e| e.generalize())?.1;
+                let encrypted_field = encrypted_field.map_err(|e| e.generalize())?;
                 if encrypted_field.type_id == ExtensionFieldTypeId::NtsEncryptedField {
                     // TODO: Discuss whether we want this check
                     Err(ParsingError::MalformedNtsExtensionFields)
@@ -593,9 +592,8 @@ impl<'a> RawExtensionField<'a> {
         buffer: &'a [u8],
         cutoff: usize,
         minimum_size: usize,
-    ) -> impl Iterator<
-        Item = Result<(usize, RawExtensionField<'a>), ParsingError<std::convert::Infallible>>,
-    > + 'a {
+    ) -> impl Iterator<Item = Result<RawExtensionField<'a>, ParsingError<std::convert::Infallible>>> + 'a
+    {
         ExtensionFieldStreamer {
             buffer,
             cutoff,
@@ -612,7 +610,7 @@ struct ExtensionFieldStreamer<'a> {
 }
 
 impl<'a> Iterator for ExtensionFieldStreamer<'a> {
-    type Item = Result<(usize, RawExtensionField<'a>), ParsingError<std::convert::Infallible>>;
+    type Item = Result<RawExtensionField<'a>, ParsingError<std::convert::Infallible>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.buffer.len() - self.offset <= self.cutoff {
@@ -621,9 +619,8 @@ impl<'a> Iterator for ExtensionFieldStreamer<'a> {
 
         match RawExtensionField::deserialize(&self.buffer[self.offset..], self.minimum_size) {
             Ok(field) => {
-                let offset = self.offset;
                 self.offset += field.wire_length();
-                Some(Ok((offset, field)))
+                Some(Ok(field))
             }
             Err(error) => {
                 self.offset = self.buffer.len();

--- a/ntp-proto/src/packet/extensionfields.rs
+++ b/ntp-proto/src/packet/extensionfields.rs
@@ -560,21 +560,26 @@ impl<'a> RawExtensionField<'a> {
     ) -> Result<Self, ParsingError<std::convert::Infallible>> {
         use ParsingError::IncorrectLength;
 
-        if data.len() < 4 {
+        let [ b0, b1, b2, b3, .. ] = data[..] else {
             return Err(IncorrectLength);
-        }
+        };
 
-        let type_id = u16::from_be_bytes(data[0..2].try_into().unwrap());
-        let field_length = u16::from_be_bytes(data[2..4].try_into().unwrap()) as usize;
+        let type_id = u16::from_be_bytes([b0, b1]);
+
+        // The Length field is a 16-bit unsigned integer that indicates the length of
+        // the entire extension field in octets, including the Padding field.
+        let field_length = u16::from_be_bytes([b2, b3]) as usize;
+
         if field_length < minimum_size || field_length % 4 != 0 {
             return Err(ParsingError::IncorrectLength);
         }
 
-        let value = data.get(4..field_length).ok_or(IncorrectLength)?;
+        // so the message bytes will include padding, and therefore may not exactly match the input
+        let message_bytes = data.get(4..field_length).ok_or(IncorrectLength)?;
 
         Ok(Self {
             type_id: ExtensionFieldTypeId::from_type_id(type_id),
-            message_bytes: value,
+            message_bytes,
         })
     }
 

--- a/ntp-proto/src/packet/extensionfields.rs
+++ b/ntp-proto/src/packet/extensionfields.rs
@@ -421,7 +421,7 @@ impl<'a> ExtensionFieldData<'a> {
         let mut is_valid_nts = true;
         let mut cookie = None;
         for field in RawExtensionField::deserialize_sequence(
-            &extension_field_bytes,
+            extension_field_bytes,
             Mac::MAXIMUM_SIZE,
             RawExtensionField::V4_UNENCRYPTED_MINIMUM_SIZE,
         ) {
@@ -543,7 +543,8 @@ impl<'a> RawEncryptedField<'a> {
 #[derive(Debug)]
 struct RawExtensionField<'a> {
     type_id: ExtensionFieldTypeId,
-    // bytes of just the message: does not include the header or padding
+    // bytes of the value and any padding. Does not include the header (field type and length)
+    // https://www.rfc-editor.org/rfc/rfc5905.html#section-7.5
     message_bytes: &'a [u8],
 }
 
@@ -552,8 +553,15 @@ impl<'a> RawExtensionField<'a> {
     const V4_UNENCRYPTED_MINIMUM_SIZE: usize = 4;
 
     fn wire_length(&self) -> usize {
-        // type_id and extension_field_length + data + padding
-        4 + next_multiple_of_usize(self.message_bytes.len(), 4)
+        // field type + length + value + padding
+        let length = 2 + 2 + self.message_bytes.len();
+
+        // All extension fields are zero-padded to a word (four octets) boundary.
+        //
+        // message_bytes should include this padding, so this should already be true
+        debug_assert_eq!(length % 4, 0);
+
+        next_multiple_of_usize(length, 4)
     }
 
     fn deserialize(
@@ -572,11 +580,12 @@ impl<'a> RawExtensionField<'a> {
         // the entire extension field in octets, including the Padding field.
         let field_length = u16::from_be_bytes([b2, b3]) as usize;
 
+        // padding is up to a multiple of 4 bytes, so a valid field length is divisible by 4
         if field_length < minimum_size || field_length % 4 != 0 {
             return Err(ParsingError::IncorrectLength);
         }
 
-        // so the message bytes will include padding, and therefore may not exactly match the input
+        // because the field length includes padding, the message bytes may not exactly match the input
         let message_bytes = data.get(4..field_length).ok_or(IncorrectLength)?;
 
         Ok(Self {

--- a/ntp-proto/src/packet/mod.rs
+++ b/ntp-proto/src/packet/mod.rs
@@ -306,7 +306,7 @@ impl<'a> NtpPacket<'a> {
                 let (header, header_size) =
                     NtpHeaderV3V4::deserialize(data).map_err(|e| e.generalize())?;
 
-                let decoded = ExtensionFieldData::deserialize(data, header_size, cipher)
+                let decoded = ExtensionFieldData::deserialize(&data[header_size..], cipher)
                     .map_err(|e| e.generalize())?;
 
                 let mac = if !decoded.remaining_bytes.is_empty() {


### PR DESCRIPTION
adds comments, and cleans up logic around slicing. 

Locally it is often difficult to verify that a certain slice operation is correct. By passing around slices instead of indices, the correctness, or at least the property that code will not panic, is more obvious.