### PR TITLE
deploy FreeBSD server

### DIFF
--- a/ntpd-rs.rc.d.example
+++ b/ntpd-rs.rc.d.example
@@ -1,35 +1,23 @@
-#!/bin/sh 
+#!/bin/sh
 
-. /etc/rc.subr 
+. /etc/rc.subr
 
+# PROVIDE: ntp_daemon
 # REQUIRE: DAEMON FILESYSTEMS devfs
 # BEFORE:  LOGIN
 # KEYWORD: nojail resume shutdown
 
-name="ntp_daemon" 
+name="ntp_daemon"
 rcvar="ntp_daemon_enable"
 
+: ${ntp_daemon_enable:="NO"}
 
-# start_cmd="${name}_start" 
-stop_cmd=":" 
 start_precmd="${name}_precmd"
 
-command="/usr/local/bin/ntp-daemon"
-pidfile="/var/run/ntpd-rs.pid"
-required_files="$command"
+command="/usr/sbin/daemon"
+procname="daemon"
+pidfile="/var/run/${name}.pid"
+command_args=" -f -o /var/log/ntp_daemon.log -H -P ${pidfile} /usr/local/bin/ntp-daemon --"
 
-: ${ntp_daemon_enable:="NO"} 
-# : ${ntp_daemon_user:="ntpd-rs"}
-# : ${ntp_daemon_group:="ntpd-rs"}
-
-
-ntp_daemon_precmd()
-{
-    export RUST_LOG="info"
-    if [ ! -d /var/run/ntpd-rs ]; then
-        install -d -o $ntp_daemon_user -g $ntp_daemon_group -m 0755 /var/run/ntpd-rs
-    fi
-}
-
-load_rc_config $name 
+load_rc_config $name
 run_rc_command "$1"

--- a/ntpd-rs.rc.d.example
+++ b/ntpd-rs.rc.d.example
@@ -15,7 +15,7 @@ rcvar="ntp_daemon_enable"
 start_precmd="${name}_precmd"
 
 command="/usr/sbin/daemon"
-procname="daemon"
+procname="ntp-daemon"
 pidfile="/var/run/${name}.pid"
 command_args=" -f -o /var/log/ntp_daemon.log -H -P ${pidfile} /usr/local/bin/ntp-daemon --"
 

--- a/ntpd-rs.rc.d.example
+++ b/ntpd-rs.rc.d.example
@@ -1,0 +1,35 @@
+#!/bin/sh 
+
+. /etc/rc.subr 
+
+# REQUIRE: DAEMON FILESYSTEMS devfs
+# BEFORE:  LOGIN
+# KEYWORD: nojail resume shutdown
+
+name="ntp_daemon" 
+rcvar="ntp_daemon_enable"
+
+
+# start_cmd="${name}_start" 
+stop_cmd=":" 
+start_precmd="${name}_precmd"
+
+command="/usr/local/bin/ntp-daemon"
+pidfile="/var/run/ntpd-rs.pid"
+required_files="$command"
+
+: ${ntp_daemon_enable:="NO"} 
+# : ${ntp_daemon_user:="ntpd-rs"}
+# : ${ntp_daemon_group:="ntpd-rs"}
+
+
+ntp_daemon_precmd()
+{
+    export RUST_LOG="info"
+    if [ ! -d /var/run/ntpd-rs ]; then
+        install -d -o $ntp_daemon_user -g $ntp_daemon_group -m 0755 /var/run/ntpd-rs
+    fi
+}
+
+load_rc_config $name 
+run_rc_command "$1"


### PR DESCRIPTION
We want to add a freebsd server running ntpd-rs to the ntp pool. I'm in the process of setting up a google compute cloud server for this purpose.


1. install cargo via rustup, and install git
1. clone the ntpd-rs repo
1. `cargo build --release --features "sentry"`. the sentry feature flag is only needed when you plan on using sentry
1. `sudo mv target/release/ntp-daemon /usr/local/bin/ntp-daemon`
1. ensure `/var/run/ntpd-rs` exists (the linux equivalent is `/run/ntpd-rs`, on freebsd this is nested inside `/var`)
1. put an ntp config at `/etc/ntpd-rs/ntp.toml`
1. be sure that the default `ntpd` deamon is stopped: `sudo service ntpd stop` and even `sudo sysrc ntpd_enable=NO` to prevent it from being started at boot 

At this point, `sudo /usr/local/bin/ntp-daemon` should work and (after a little while) synchronize the time. But we want to run this as a daemon. FreeBSD does not use `systemd`, but instead a thing called `rc.d`.

So I put this file at `/etc/rc.d/ntp-daemon`:

```sh
#!/bin/sh 

. /etc/rc.subr 

# REQUIRE: DAEMON FILESYSTEMS devfs
# BEFORE:  LOGIN
# KEYWORD: nojail resume shutdown

name="ntp_daemon" 
rcvar="ntp_daemon_enable"


# start_cmd="${name}_start" 
stop_cmd=":" 
start_precmd="${name}_precmd"

command="/usr/local/bin/ntp-daemon"
pidfile="/var/run/ntpd-rs.pid"
required_files="$command"

: ${ntp_daemon_enable:="NO"} 
# : ${ntp_daemon_user:="ntpd-rs"}
# : ${ntp_daemon_group:="ntpd-rs"}


ntp_daemon_precmd()
{
    export RUST_LOG="info"
    if [ ! -d /var/run/ntpd-rs ]; then
        install -d -o $ntp_daemon_user -g $ntp_daemon_group -m 0755 /var/run/ntpd-rs
    fi
}

load_rc_config $name 
run_rc_command "$1"
```

We want it to start at boot

```
sudo sysrc ntp_daemon_enable=NO
```

Then the daemon is started using 

```
rc_debug=true sudo -E service ntp-daemon start
```

## Users

The script above has some commented lines regarding users. I used the following commands

```
sudo pw groupadd ntpd-rs
sudo pw useradd ntpd-rs -g ntpd-rs -d /nonexistent -s /usr/sbin/nologin
```

to create an `ntpd-rs` group and and user (and the user is in the group). However, this user is not allowed to touch the clock.

For the linux systems, we use `AmbientCapabilities=CAP_SYS_TIME` in the systemd service file to configure the capabilities. There does not seem to be something equivalent for `rc.d`, and other approaches also don't seem to work on the VM that I have access to.
