### PR TITLE
Removed custom PeerConfig deserialization

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -123,49 +123,45 @@ The ntp-daemon's primary configuration method is through a TOML configuration fi
 Peers are configured in the peers section, which should consist of a list of peers. Per peer, the following options are available:
 | Option | Default | Description |
 | --- | --- | --- |
-| mode | server | Type of peer connection to create. Can be any of `server`, `nts-server` or `pool` (for meaning of these, see below). |
-| addr | | Address of the server or pool. The default port (123) is automatically appended if not given. (not valid for nts connections) |
-| addr-ke | | Address of the nts server. The default port (4460) is automatically appended if not given. (only valid for nts connections) |
+| mode | server | Type of peer connection to create. Can be any of `simple`, `nts` or `pool` (for meaning of these, see below). |
+| address | | Address of the server, pool or nts server. The default port (123 for server or pool, 4460 for nts) is automatically appended if not given. |
 | max-peers | 4 | Maximum number of peers to create from the pool. (only  valid for pools) |
 | certificates | | Path to a pem file containing additional root certificates to accept for the TLS connection to the nts server. In addition to these certificates, the system certificates will also be accepted. (only valid for nts connections) |
 
-##### Server peers
+##### Simple peers
 
-Server peers are direct NTP connections to a single remote server. This is the default. In addition to being able to be configured as a struct, they can also be configured from a string. This is useful when defining multiple servers. For example:
+Simple peers are direct NTP connections to a single remote server. This is the default. To configure multiple servers, add a `[[peers]]` section for each server. For example:
 
 ```
-# As a simple list (pool servers from ntppool.org)
-peers = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org"]
-
-# Or by providing written out configuration
+# Multiple server can be configured by defining multiple `[[peers]]` sections
 [[peers]]
-addr = "0.pool.ntp.org:123"
+address = "0.pool.ntp.org:123"
 
 [[peers]]
-addr = "1.pool.ntp.org:123"
+address = "1.pool.ntp.org:123"
 ```
 
 ##### Nts peers
 
-A peer in `nts-server` mode will use NTS (Network Times Security) to communicate with its server. The server must support NTS. The configuration requires the address of the Key Exchange server (the address of the actual NTP server that ends up being used may be different). For example:
+A peer in `nts` mode will use NTS (Network Times Security) to communicate with its server. The server must support NTS. The configuration requires the address of the Key Exchange server (the address of the actual NTP server that ends up being used may be different). For example:
 
 ```
 [[peers]]
-mode = "nts-server"
-ke-addr = "time.cloudflare.com:4460"
+mode = "nts"
+address = "time.cloudflare.com:4460"
 ```
 
 ##### Pool
 
-`Pool` mode is a convenient way to configure many NTP servers, without having to worry about individual servers' IP addresses.
+`pool` mode is a convenient way to configure many NTP servers, without having to worry about individual servers' IP addresses.
 
-A peer in `Pool` mode will try to acquire `max_peers` addresses of NTP servers from the pool. `ntpd-rs` will actively try to keep a pool filled up. For instance if a server cannot be reached, a different server will be picked from the pool.
+A peer in `pool` mode will try to acquire `max_peers` addresses of NTP servers from the pool. `ntpd-rs` will actively try to keep a pool filled up. For instance if a server cannot be reached, a different server will be picked from the pool.
 
 An example configuration for the ntppool.org ntp pool can look like
 ```
 [[peers]]
-addr = "pool.ntp.org"
-mode = "Pool"
+address = "pool.ntp.org"
+mode = "pool"
 max-peers = 4
 ```
 
@@ -174,7 +170,7 @@ max-peers = 4
 Interfaces on which to act as a server are configured in the `server` section. Per interface configured, the following options are available:
 | Option | Default | Description |
 | --- | --- | --- |
-| addr | | Address of the interface to bind to. |
+| address | | Address of the interface to bind to. |
 | allowlist | ["0.0.0.0/0", "::/0"] | List of IP subnets allowed to contact through this interface. |
 | allowlist-action | | Action taken when a client's IP is not on the list of allowed clients. Can be `Ignore` to ignore packets from such clients, or `Deny` to send a deny response to those clients. |
 | denylist | [] | List of IP subnets disallowed to contact through this interface. |
@@ -194,7 +190,7 @@ Servers configured via the `server` section can also support NTS. To enable this
 | cert-chain-path | | Path to the full chain TLS certificate for the server. Note that currently self-signed certificates are not supported. |
 | key-der-path | | Path to the TLS private key for the server. |
 | timeout-ms | 1000 | Timeout on NTS-KE sessions, after which the server decides to hang up. This is to prevent large resource utilization from old and or inactive sessions. Timeout duration is in milliseconds. |
-| addr | | Address of the interface to bind to for the NTS-KE server. |
+| address | | Address of the interface to bind to for the NTS-KE server. |
 
 Our implementation of NTS follows the recommendations of section 6 in [RFC8915](https://www.rfc-editor.org/rfc/rfc8915.html). Currently, the master keys for encryption of the cookies are generated internally, and their generation can be controlled via the settings in the `keyset` section
 | Option | Default | Description |
@@ -295,16 +291,13 @@ The high performance clock algorithm has quite a few options. Most of these are 
 # Other values include trace, debug, warn and error
 log-filter = "info"
 
-# Peers can be configured as a simple list (pool servers from ntppool.org)
-peers = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org"]
-
 # Or by providing written out configuration
 # [[peers]]
-# addr = "0.pool.ntp.org:123"
+# address = "0.pool.ntp.org:123"
 #
 
 # [[peers]]
-# addr = "1.pool.ntp.org:123"
+# address = "1.pool.ntp.org:123"
 
 # System parameters used in filtering and steering the clock:
 [system]

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -124,8 +124,8 @@ Peers are configured in the peers section, which should consist of a list of pee
 | Option | Default | Description |
 | --- | --- | --- |
 | mode | server | Type of peer connection to create. Can be any of `simple`, `nts` or `pool` (for meaning of these, see below). |
-| address | | Address of the server, pool or nts server. The default port (123 for server or pool, 4460 for nts) is automatically appended if not given. |
-| max-peers | 4 | Maximum number of peers to create from the pool. (only  valid for pools) |
+| address | | Address of the server, pool or nts server. The default port (123 for `simple` or `pool`, 4460 for `nts`) is automatically appended if not given. |
+| max-peers | 4 | Maximum number of peers to create from the pool. (only valid for pools) |
 | certificates | | Path to a pem file containing additional root certificates to accept for the TLS connection to the nts server. In addition to these certificates, the system certificates will also be accepted. (only valid for nts connections) |
 
 ##### Simple peers

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -126,7 +126,7 @@ Peers are configured in the peers section, which should consist of a list of pee
 | mode | server | Type of peer connection to create. Can be any of `server`, `nts-server` or `pool` (for meaning of these, see below). |
 | addr | | Address of the server or pool. The default port (123) is automatically appended if not given. (not valid for nts connections) |
 | addr-ke | | Address of the nts server. The default port (4460) is automatically appended if not given. (only valid for nts connections) |
-| max-peers | 1 | Maximum number of peers to create from the pool. (only  valid for pools) |
+| max-peers | 4 | Maximum number of peers to create from the pool. (only  valid for pools) |
 | certificates | | Path to a pem file containing additional root certificates to accept for the TLS connection to the nts server. In addition to these certificates, the system certificates will also be accepted. (only valid for nts connections) |
 
 ##### Server peers

--- a/config/nts.client.toml
+++ b/config/nts.client.toml
@@ -3,9 +3,8 @@ log-filter = "info"
 
 # See CONFIGURATION.md for how to set up certificates
 [[peers]]
-mode = "NtsServer"
-addr = "localhost:123"
-ke-addr =  "localhost:4460"
+mode = "nts"
+address =  "localhost:4460"
 certificate = "path/to/certificate/authority.pem"
 
 # System parameters used in filtering and steering the clock:

--- a/config/nts.server.toml
+++ b/config/nts.server.toml
@@ -4,7 +4,7 @@ log-filter = "info"
 # the server will get its time from the NTP pool
 [[peers]]
 mode = "pool"
-addr = "pool.ntp.org"
+address = "pool.ntp.org"
 max-peers = 4
 
 [[server]]

--- a/ntp-daemon/src/config/mod.rs
+++ b/ntp-daemon/src/config/mod.rs
@@ -466,41 +466,47 @@ mod tests {
 
     #[test]
     fn test_config() {
-        let config: Config = toml::from_str("[[peers]]\naddr = \"example.com\"").unwrap();
+        let config: Config =
+            toml::from_str("[[peers]]\nmode = \"simple\"\naddress = \"example.com\"").unwrap();
         assert_eq!(
             config.peers,
             vec![PeerConfig::Standard(StandardPeerConfig {
-                addr: NormalizedAddress::new_unchecked("example.com", 123),
+                addr: NormalizedAddress::new_unchecked("example.com", 123).into(),
             })]
         );
 
-        let config: Config =
-            toml::from_str("log-filter = \"\"\n[[peers]]\naddr = \"example.com\"").unwrap();
+        let config: Config = toml::from_str(
+            "log-filter = \"\"\n[[peers]]\nmode = \"simple\"\naddress = \"example.com\"",
+        )
+        .unwrap();
         assert!(config.log_filter.is_none());
         assert_eq!(
             config.peers,
             vec![PeerConfig::Standard(StandardPeerConfig {
-                addr: NormalizedAddress::new_unchecked("example.com", 123),
+                addr: NormalizedAddress::new_unchecked("example.com", 123).into(),
             })]
         );
 
-        let config: Config =
-            toml::from_str("log-filter = \"info\"\n[[peers]]\naddr = \"example.com\"").unwrap();
+        let config: Config = toml::from_str(
+            "log-filter = \"info\"\n[[peers]]\nmode = \"simple\"\naddress = \"example.com\"",
+        )
+        .unwrap();
         assert!(config.log_filter.is_some());
         assert_eq!(
             config.peers,
             vec![PeerConfig::Standard(StandardPeerConfig {
-                addr: NormalizedAddress::new_unchecked("example.com", 123),
+                addr: NormalizedAddress::new_unchecked("example.com", 123).into(),
             })]
         );
 
-        let config: Config =
-            toml::from_str("[[peers]]\naddr = \"example.com\"\n[system]\npanic-threshold = 0")
-                .unwrap();
+        let config: Config = toml::from_str(
+            "[[peers]]\nmode = \"simple\"\naddress = \"example.com\"\n[system]\npanic-threshold = 0",
+        )
+        .unwrap();
         assert_eq!(
             config.peers,
             vec![PeerConfig::Standard(StandardPeerConfig {
-                addr: NormalizedAddress::new_unchecked("example.com", 123),
+                addr: NormalizedAddress::new_unchecked("example.com", 123).into(),
             })]
         );
         assert_eq!(
@@ -513,13 +519,13 @@ mod tests {
         );
 
         let config: Config = toml::from_str(
-            "[[peers]]\naddr = \"example.com\"\n[system]\npanic-threshold = \"inf\"",
+            "[[peers]]\nmode = \"simple\"\naddress = \"example.com\"\n[system]\npanic-threshold = \"inf\"",
         )
         .unwrap();
         assert_eq!(
             config.peers,
             vec![PeerConfig::Standard(StandardPeerConfig {
-                addr: NormalizedAddress::new_unchecked("example.com", 123),
+                addr: NormalizedAddress::new_unchecked("example.com", 123).into(),
             })]
         );
         assert!(config.system.system.panic_threshold.forward.is_none());
@@ -529,7 +535,8 @@ mod tests {
             r#"
             log-filter = "info"
             [[peers]]
-            addr = "example.com"
+            mode = "simple"
+            address = "example.com"
             [observe]
             path = "/foo/bar/observe"
             mode = 0o567
@@ -553,7 +560,7 @@ mod tests {
         assert_eq!(
             config.peers,
             vec![PeerConfig::Standard(StandardPeerConfig {
-                addr: NormalizedAddress::new_unchecked("example.com", 123),
+                addr: NormalizedAddress::new_unchecked("example.com", 123).into(),
             })]
         );
     }
@@ -605,7 +612,7 @@ mod tests {
         let config: Result<Config, _> = toml::from_str(
             r#"
             [[peers]]
-            addr = ":invalid:ipv6:123"
+            address = ":invalid:ipv6:123"
             "#,
         );
 

--- a/ntp-daemon/src/config/peer.rs
+++ b/ntp-daemon/src/config/peer.rs
@@ -23,8 +23,11 @@ pub struct StandardPeerConfig {
 pub struct NtsPeerConfig {
     #[serde(rename = "address")]
     pub ke_addr: NtsKeAddress,
-    #[serde(deserialize_with = "deserialize_certificates")]
-    #[serde(default = "default_certificates")]
+    #[serde(
+        deserialize_with = "deserialize_certificates",
+        default = "default_certificates",
+        rename = "certificate"
+    )]
     pub certificates: Arc<[Certificate]>,
 }
 

--- a/ntp-daemon/src/config/peer.rs
+++ b/ntp-daemon/src/config/peer.rs
@@ -281,7 +281,6 @@ impl std::fmt::Display for NormalizedAddress {
     }
 }
 
-#[cfg(test)]
 impl TryFrom<&str> for StandardPeerConfig {
     type Error = std::io::Error;
 
@@ -292,7 +291,6 @@ impl TryFrom<&str> for StandardPeerConfig {
     }
 }
 
-#[cfg(test)]
 impl<'a> TryFrom<&'a str> for PeerConfig {
     type Error = std::io::Error;
 

--- a/ntp-daemon/src/config/peer.rs
+++ b/ntp-daemon/src/config/peer.rs
@@ -12,13 +12,14 @@ use serde::{de, Deserialize, Deserializer};
 use crate::keyexchange::certificates_from_file;
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(deny_unknown_fields)]
 pub struct StandardPeerConfig {
     #[serde(rename = "address")]
     pub addr: NtpAddress,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct NtsPeerConfig {
     #[serde(rename = "address")]
     pub ke_addr: NtsKeAddress,

--- a/ntp-daemon/src/lib.rs
+++ b/ntp-daemon/src/lib.rs
@@ -91,7 +91,7 @@ async fn run(options: NtpDaemonOptions) -> Result<(), Box<dyn Error>> {
     let clock_config = config.clock;
 
     #[cfg(not(feature = "hardware-timestamping"))]
-    let clock_config = ClockConfig::default();
+    let clock_config = config::ClockConfig::default();
 
     ::tracing::debug!("Configuration loaded, spawning daemon jobs");
     let (main_loop_handle, channels) = crate::spawn(

--- a/ntp-daemon/src/lib.rs
+++ b/ntp-daemon/src/lib.rs
@@ -21,7 +21,6 @@ pub mod tracing;
 
 use std::{error::Error, sync::Arc};
 
-use config::ClockConfig;
 pub use config::Config;
 pub use observer::{ObservablePeerState, ObservableState};
 pub use system::spawn;

--- a/ntp-daemon/src/spawn/nts.rs
+++ b/ntp-daemon/src/spawn/nts.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use thiserror::Error;
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -69,7 +71,7 @@ impl NtsSpawner {
                 SpawnAction::create(
                     PeerId::new(),
                     addr,
-                    self.config.ke_addr.clone(),
+                    self.config.ke_addr.deref().clone(),
                     Some(ke.nts),
                 ),
             ))

--- a/ntp-daemon/src/spawn/pool.rs
+++ b/ntp-daemon/src/spawn/pool.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, ops::Deref};
 
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -69,7 +69,8 @@ impl PoolSpawner {
                 if let Some(addr) = self.known_ips.pop() {
                     let id = PeerId::new();
                     self.current_peers.push(PoolPeer { id, addr });
-                    let action = SpawnAction::create(id, addr, self.config.addr.clone(), None);
+                    let action =
+                        SpawnAction::create(id, addr, self.config.addr.deref().clone(), None);
                     tracing::debug!(?action, "intending to spawn new pool peer at");
 
                     action_tx
@@ -126,7 +127,7 @@ impl BasicSpawner for PoolSpawner {
     }
 
     fn get_addr_description(&self) -> String {
-        format!("{} ({})", self.config.addr, self.config.max_peers)
+        format!("{} ({})", self.config.addr.deref(), self.config.max_peers)
     }
 
     fn get_description(&self) -> &str {
@@ -155,7 +156,8 @@ mod tests {
 
         let pool = PoolSpawner::new(
             PoolPeerConfig {
-                addr: NormalizedAddress::with_hardcoded_dns("example.com", 123, addresses.to_vec()),
+                addr: NormalizedAddress::with_hardcoded_dns("example.com", 123, addresses.to_vec())
+                    .into(),
                 max_peers: 2,
             },
             NETWORK_WAIT_PERIOD,
@@ -192,7 +194,8 @@ mod tests {
 
         let pool = PoolSpawner::new(
             PoolPeerConfig {
-                addr: NormalizedAddress::with_hardcoded_dns("example.com", 123, addresses.to_vec()),
+                addr: NormalizedAddress::with_hardcoded_dns("example.com", 123, addresses.to_vec())
+                    .into(),
                 max_peers: 2,
             },
             NETWORK_WAIT_PERIOD,
@@ -235,7 +238,7 @@ mod tests {
     async fn works_if_address_does_not_resolve() {
         let pool = PoolSpawner::new(
             PoolPeerConfig {
-                addr: NormalizedAddress::with_hardcoded_dns("does.not.resolve", 123, vec![]),
+                addr: NormalizedAddress::with_hardcoded_dns("does.not.resolve", 123, vec![]).into(),
                 max_peers: 2,
             },
             NETWORK_WAIT_PERIOD,

--- a/ntp-daemon/src/spawn/standard.rs
+++ b/ntp-daemon/src/spawn/standard.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, ops::Deref};
 
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -70,7 +70,7 @@ impl StandardSpawner {
         action_tx
             .send(SpawnEvent::new(
                 self.id,
-                SpawnAction::create(PeerId::new(), addr, self.config.addr.clone(), None),
+                SpawnAction::create(PeerId::new(), addr, self.config.addr.deref().clone(), None),
             ))
             .await?;
         Ok(())
@@ -140,7 +140,8 @@ mod tests {
                     "example.com",
                     123,
                     vec!["127.0.0.1:123".parse().unwrap()],
-                ),
+                )
+                .into(),
             },
             NETWORK_WAIT_PERIOD,
         );
@@ -169,7 +170,8 @@ mod tests {
                     "example.com",
                     123,
                     vec!["127.0.0.1:123".parse().unwrap()],
-                ),
+                )
+                .into(),
             },
             NETWORK_WAIT_PERIOD,
         );
@@ -206,7 +208,8 @@ mod tests {
                     "europe.pool.ntp.org",
                     123,
                     addresses.to_vec(),
-                ),
+                )
+                .into(),
             },
             NETWORK_WAIT_PERIOD,
         );
@@ -256,7 +259,7 @@ mod tests {
     async fn works_if_address_does_not_resolve() {
         let spawner = StandardSpawner::new(
             StandardPeerConfig {
-                addr: NormalizedAddress::with_hardcoded_dns("does.not.resolve", 123, vec![]),
+                addr: NormalizedAddress::with_hardcoded_dns("does.not.resolve", 123, vec![]).into(),
             },
             NETWORK_WAIT_PERIOD,
         );

--- a/ntp-daemon/testdata/config/ntp.toml
+++ b/ntp-daemon/testdata/config/ntp.toml
@@ -1,4 +1,6 @@
-peers=["example.com"]
+[[peers]]
+mode = "simple"
+address = "example.com"
 
 [system]
 min-intersection-survivors = 2

--- a/ntp-daemon/testdata/config/other.toml
+++ b/ntp-daemon/testdata/config/other.toml
@@ -1,4 +1,6 @@
-peers=["example.com"]
+[[peers]]
+mode = "simple"
+address = "example.com"
 
 [system]
 min-intersection-survivors = 3

--- a/ntp.server.toml
+++ b/ntp.server.toml
@@ -5,7 +5,7 @@ log-filter = "info"
 # for more information
 [[peers]]
 mode = "pool"
-addr = "ntpd-rs.pool.ntp.org"
+address = "ntpd-rs.pool.ntp.org"
 max-peers = 4
 
 # Alternative configuration for IPv6 only machines

--- a/ntp.toml
+++ b/ntp.toml
@@ -5,7 +5,7 @@ log-filter = "info"
 # for more information
 [[peers]]
 mode = "pool"
-addr = "ntpd-rs.pool.ntp.org"
+address = "ntpd-rs.pool.ntp.org"
 max-peers = 4
 
 # Alternative configuration for IPv6 only machines

--- a/pkg/common/ntp.toml.default
+++ b/pkg/common/ntp.toml.default
@@ -9,22 +9,22 @@ log-filter = "info"
 ## to discover 4 distinct peers).
 [[peers]]
 mode = "pool"
-addr = "ntpd-rs.pool.ntp.org"
+address = "ntpd-rs.pool.ntp.org"
 max-peers = 4
 
 ## If you have an NTS server, you can configure a peer that connects using NTS
 ## by adding a configuration such as the one below
 #[[peers]]
-#mode = "nts-server"
+#mode = "nts"
 # NTS service from NETNOD: https://www.netnod.se/nts/network-time-security
-#ke-addr = "nts.netnod.se"
+#address = "nts.netnod.se"
 
 ## A peer in server mode will only create a single peer in contrast to the
 ## multiple peers of a pool. This is the recommended peer mode if you only
 ## have an IP address for your peer.
 #[[peers]]
 #mode = "server"
-#addr = "ntpd-rs.pool.ntp.org"
+#address = "ntpd-rs.pool.ntp.org"
 
 ## Using the observe socket you can retrieve statistical information about the
 ## daemon while it is running. You can use the `ntp-ctl` or prometheus based

--- a/test-keys/unsafe.nts.client.toml
+++ b/test-keys/unsafe.nts.client.toml
@@ -3,9 +3,8 @@ log-filter = "info"
 
 # uses an unsecure certificate!
 [[peers]]
-mode = "NtsServer"
-addr = "localhost:123"
-ke-addr =  "localhost:4460"
+mode = "nts"
+address =  "localhost:4460"
 certificate = "test-keys/testca.pem"
 
 # System parameters used in filtering and steering the clock:

--- a/test-keys/unsafe.nts.server.toml
+++ b/test-keys/unsafe.nts.server.toml
@@ -4,7 +4,7 @@ log-filter = "info"
 # the server will get its time from the NTP pool
 [[peers]]
 mode = "pool"
-addr = "pool.ntp.org"
+address = "pool.ntp.org"
 max-peers = 4
 
 [[server]]


### PR DESCRIPTION
- Removed peer config deserialization
- Renamed `addr` to `address` and `ke-addr` to `address` for peer config
- Renamed `mode` variants