### PR TITLE
Set lower minimum dependencies in our Cargo.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  
+
 - package-ecosystem: cargo
   directory: "/"
   schedule:
     interval: daily
+  versioning-strategy: lockfile-only
   open-pull-requests-limit: 10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,17 @@ panic = "abort"
 strip = "debuginfo"
 
 [workspace.dependencies]
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", default-features = false, features = ["std", "fmt", "ansi"] }
-serde = { version = "1.0.177", features = ["derive"] }
-serde_json = "1.0.104"
-rand = "0.8.5"
-arbitrary = { version = "1.3.0" }
-thiserror = "1.0.44"
-libc = "0.2.147"
-tokio = "1.29.1"
-toml = "0.7.6"
-async-trait = "0.1.72"
+tracing = "0.1.21"
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["std", "fmt", "ansi"] }
+serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0"
+rand = "0.8.0"
+arbitrary = { version = "1.0" }
+thiserror = "1.0.10"
+libc = "0.2.145"
+tokio = "1.28"
+toml = ">=0.5.0,<0.8.0"
+async-trait = "0.1.22"
 
 # our own crates used as dependencies, same version as the workspace version
 ntp-ctl = { version = "0.3.6", path = "./ntp-ctl" }
@@ -64,16 +64,16 @@ ntp-proto = { version = "0.3.6", path = "./ntp-proto" }
 ntp-udp = { version = "0.3.6", path = "./ntp-udp" }
 
 # prometheus support
-prometheus-client = "0.21.2"
+prometheus-client = ">=0.19.0,<0.22.0"
 
 # TLS
-rustls = "0.21.2"
-rustls-pemfile = "1.0.3"
-rustls-native-certs = "0.6.3"
+rustls = "0.21.0"
+rustls-pemfile = "1.0"
+rustls-native-certs = "0.6.0"
 
 # crypto
-aead = "0.5.2"
+aead = "0.5.0"
 aes-siv = "0.7.0"
 # Note: md5 is needed to calculate ReferenceIDs for IPv6 addresses per RFC5905
-md-5 = "0.10.5"
-zeroize = "1.6.0"
+md-5 = "0.10.0"
+zeroize = "1.5"


### PR DESCRIPTION
These lower minimum versions were set by lowering the version constraints until either tests started failing or compilation failed. I've also changed dependabot to no longer update our Cargo.toml, although that will also result in dependabot no longer giving us notifications for any semver incompatible changes, but unfortunately the `increase-if-necessary` dependabot strategy is not supported for cargo. But if we are packaging into OSes then we should treat backwards incompatible upgrades with care anyway. Note that our lockfile still contains the latest versions, and we probably want to add a CI step that runs every once in a while to check that our minimum versions still compile and test correctly.