### PR TITLE
Use renames instead of aliases for peers, servers and nts_ke_servers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -114,24 +114,26 @@ The ntp-daemon's primary configuration method is through a TOML configuration fi
 
 #### Peer configuration
 
-Peers are configured in the peers section, which should consist of a list of peers. Per peer, the following options are available:
+Peers are configured in the peers section, which should consist of a list of peers. Per `[[peer]]`, the following options are available:
 | Option       | Default | Description                                                                                                                                                                                                                       |
 |--------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| mode         | server  | Type of peer connection to create. Can be any of `simple`, `nts` or `pool` (for meaning of these, see below).                                                                                                                     |
+| mode         |         | Type of peer connection to create. Can be any of `simple`, `nts` or `pool` (for meaning of these, see below).                                                                                                                     |
 | address      |         | Address of the server, pool or nts server. The default port (123 for `simple` or `pool`, 4460 for `nts`) is automatically appended if not given.                                                                                  |
 | count        | 4       | Maximum number of peers to create from the pool. (only valid for pools)                                                                                                                                                           |
 | certificate_authority |         | Path to a pem file containing additional root certificates to accept for the TLS connection to the nts server. In addition to these certificates, the system certificates will also be accepted. (only valid for nts connections) |
 
 ##### Simple peers
 
-Simple peers are direct NTP connections to a single remote server. This is the default. To configure multiple servers, add a `[[peers]]` section for each server. For example:
+Simple peers are direct NTP connections to a single remote server. This is the default. To configure multiple servers, add a `[[peer]]` section for each server. For example:
 
 ```
-# Multiple server can be configured by defining multiple `[[peers]]` sections
-[[peers]]
+# Multiple server can be configured by defining multiple `[[peer]]` sections
+[[peer]]
+mode = "simple"
 address = "0.pool.ntp.org:123"
 
-[[peers]]
+[[peer]]
+mode = "simple"
 address = "1.pool.ntp.org:123"
 ```
 
@@ -140,7 +142,7 @@ address = "1.pool.ntp.org:123"
 A peer in `nts` mode will use NTS (Network Times Security) to communicate with its server. The server must support NTS. The configuration requires the address of the Key Exchange server (the address of the actual NTP server that ends up being used may be different). For example:
 
 ```
-[[peers]]
+[[peer]]
 mode = "nts"
 address = "time.cloudflare.com:4460"
 ```
@@ -153,7 +155,7 @@ A peer in `pool` mode will try to acquire `max_peers` addresses of NTP servers f
 
 An example configuration for the ntppool.org ntp pool can look like
 ```
-[[peers]]
+[[peer]]
 address = "pool.ntp.org"
 mode = "pool"
 count = 4
@@ -300,12 +302,13 @@ The high performance clock algorithm has quite a few options. Most of these are 
 # Other values include trace, debug, warn and error
 log-level = "info"
 
-# Or by providing written out configuration
-# [[peers]]
+# [[peer]]
+# mode = "simple"
 # address = "0.pool.ntp.org:123"
 #
 
-# [[peers]]
+# [[peer]]
+# mode = "simple"
 # address = "1.pool.ntp.org:123"
 
 # System parameters used in filtering and steering the clock:

--- a/config/nts.client.toml
+++ b/config/nts.client.toml
@@ -4,7 +4,7 @@ log-level = "info"
 observation-path = "/run/ntpd-rs/observe"
 
 # See CONFIGURATION.md for how to set up certificates
-[[peers]]
+[[peer]]
 mode = "nts"
 address =  "localhost:4460"
 certificate_authority = "path/to/certificate/authority.pem"

--- a/config/nts.server.toml
+++ b/config/nts.server.toml
@@ -3,7 +3,7 @@
 log-level = "info"
 
 # the server will get its time from the NTP pool
-[[peers]]
+[[peer]]
 mode = "pool"
 address = "pool.ntp.org"
 count = 4

--- a/ntp.server.toml
+++ b/ntp.server.toml
@@ -5,13 +5,13 @@ observation-path = "/run/ntpd-rs/observe"
 
 # Pool servers from ntppool.org. See http://www.pool.ntp.org/join.html
 # for more information
-[[peers]]
+[[peer]]
 mode = "pool"
 address = "ntpd-rs.pool.ntp.org"
 count = 4
 
 # Alternative configuration for IPv6 only machines
-#[[peers]]
+#[[peer]]
 #mode = "pool"
 #addr = "2.pool.ntp.org"
 #count = 4

--- a/ntp.toml
+++ b/ntp.toml
@@ -5,13 +5,13 @@ observation-path = "/run/ntpd-rs/observe"
 
 # Pool servers from ntppool.org. See http://www.pool.ntp.org/join.html
 # for more information
-[[peers]]
+[[peer]]
 mode = "pool"
 address = "ntpd-rs.pool.ntp.org"
 count = 4
 
 # Alternative configuration for IPv6 only machines
-#[[peers]]
+#[[peer]]
 #mode = "pool"
 #address = "2.pool.ntp.org"
 #count = 4

--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -272,11 +272,11 @@ pub struct LoggingObservabilityConfig {
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
-    #[serde(alias = "peer")]
+    #[serde(rename = "peer")]
     pub peers: Vec<PeerConfig>,
-    #[serde(alias = "server", default)]
+    #[serde(rename = "server", default)]
     pub servers: Vec<ServerConfig>,
-    #[serde(alias = "nts-ke-server", default)]
+    #[serde(rename = "nts-ke-server", default)]
     pub nts_ke: Vec<NtsKeConfig>,
     #[serde(default)]
     pub synchronization: CombinedSynchronizationConfig,
@@ -452,7 +452,7 @@ mod tests {
     #[test]
     fn test_config() {
         let config: Config =
-            toml::from_str("[[peers]]\nmode = \"simple\"\naddress = \"example.com\"").unwrap();
+            toml::from_str("[[peer]]\nmode = \"simple\"\naddress = \"example.com\"").unwrap();
         assert_eq!(
             config.peers,
             vec![PeerConfig::Standard(StandardPeerConfig {
@@ -462,7 +462,7 @@ mod tests {
         assert!(config.observability.log_level.is_none());
 
         let config: Config = toml::from_str(
-            "[observability]\nlog-level = \"info\"\n[[peers]]\nmode = \"simple\"\naddress = \"example.com\"",
+            "[observability]\nlog-level = \"info\"\n[[peer]]\nmode = \"simple\"\naddress = \"example.com\"",
         )
             .unwrap();
         assert_eq!(config.observability.log_level, Some(LogLevel::Info));
@@ -474,7 +474,7 @@ mod tests {
         );
 
         let config: Config = toml::from_str(
-            "[[peers]]\nmode = \"simple\"\naddress = \"example.com\"\n[synchronization]\nsingle-step-panic-threshold = 0",
+            "[[peer]]\nmode = \"simple\"\naddress = \"example.com\"\n[synchronization]\nsingle-step-panic-threshold = 0",
         )
             .unwrap();
         assert_eq!(
@@ -501,7 +501,7 @@ mod tests {
         );
 
         let config: Config = toml::from_str(
-            "[[peers]]\nmode = \"simple\"\naddress = \"example.com\"\n[synchronization]\nsingle-step-panic-threshold = \"inf\"",
+            "[[peer]]\nmode = \"simple\"\naddress = \"example.com\"\n[synchronization]\nsingle-step-panic-threshold = \"inf\"",
         )
             .unwrap();
         assert_eq!(
@@ -525,7 +525,7 @@ mod tests {
 
         let config: Config = toml::from_str(
             r#"
-            [[peers]]
+            [[peer]]
             mode = "simple"
             address = "example.com"
             [peer-defaults]
@@ -614,7 +614,8 @@ mod tests {
     fn toml_peers_invalid() {
         let config: Result<Config, _> = toml::from_str(
             r#"
-            [[peers]]
+            [[peer]]
+            mode = "simple"
             address = ":invalid:ipv6:123"
             "#,
         );

--- a/ntpd/testdata/config/ntp.toml
+++ b/ntpd/testdata/config/ntp.toml
@@ -1,4 +1,4 @@
-[[peers]]
+[[peer]]
 mode = "simple"
 address = "example.com"
 

--- a/ntpd/testdata/config/other.toml
+++ b/ntpd/testdata/config/other.toml
@@ -1,4 +1,4 @@
-[[peers]]
+[[peer]]
 mode = "simple"
 address = "example.com"
 

--- a/pkg/common/ntp.toml.default
+++ b/pkg/common/ntp.toml.default
@@ -13,14 +13,14 @@ observation-path = "/run/ntpd-rs/observe"
 ## these blocks to add more peers to your configuration.
 ## Our default configuration spawns a pool of peers (by default this attempts
 ## to discover 4 distinct peers).
-[[peers]]
+[[peer]]
 mode = "pool"
 address = "ntpd-rs.pool.ntp.org"
 count = 4
 
 ## If you have an NTS server, you can configure a peer that connects using NTS
 ## by adding a configuration such as the one below
-#[[peers]]
+#[[peer]]
 #mode = "nts"
 # NTS service from NETNOD: https://www.netnod.se/nts/network-time-security
 #address = "nts.netnod.se"
@@ -28,7 +28,7 @@ count = 4
 ## A peer in server mode will only create a single peer in contrast to the
 ## multiple peers of a pool. This is the recommended peer mode if you only
 ## have an IP address for your peer.
-#[[peers]]
+#[[peer]]
 #mode = "simple"
 #address = "ntpd-rs.pool.ntp.org"
 

--- a/test-keys/unsafe.nts.client.toml
+++ b/test-keys/unsafe.nts.client.toml
@@ -4,7 +4,7 @@ log-level = "info"
 observation-path = "/run/ntpd-rs/observe"
 
 # uses an unsecure certificate!
-[[peers]]
+[[peer]]
 mode = "nts"
 address =  "localhost:4460"
 certificates = "test-keys/testca.pem"

--- a/test-keys/unsafe.nts.server.toml
+++ b/test-keys/unsafe.nts.server.toml
@@ -4,7 +4,7 @@ log-level = "info"
 observation-path = "/run/ntpd-rs/observe"
 
 # the server will get its time from the NTP pool
-[[peers]]
+[[peer]]
 mode = "pool"
 address = "pool.ntp.org"
 count = 4


### PR DESCRIPTION
Right now things like peers can be configured in a section like `[[peers]]` or `[[peer]]`, but this could cause confusion. Instead we should support only one of those options. I opted to go for singulars only in the configuration file.