### PR TITLE
Separate out the algorithm config in its own section

### DIFF
--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -21,7 +21,7 @@ use self::{
 use super::{ObservablePeerTimedata, StateUpdate, TimeSyncController};
 
 mod combiner;
-mod config;
+pub(super) mod config;
 mod matrix;
 mod peer;
 mod select;

--- a/ntp-proto/src/algorithm/mod.rs
+++ b/ntp-proto/src/algorithm/mod.rs
@@ -81,5 +81,5 @@ pub trait TimeSyncController<C: NtpClock, PeerID: Hash + Eq + Copy + Debug> {
 
 mod kalman;
 
+pub use kalman::config::AlgorithmConfig;
 pub use kalman::KalmanClockController;
-pub type DefaultTimeSyncController<C, PeerID> = kalman::KalmanClockController<C, PeerID>;

--- a/ntp-proto/src/config.rs
+++ b/ntp-proto/src/config.rs
@@ -5,7 +5,10 @@ use serde::{
     Deserialize, Deserializer,
 };
 
-use crate::time_types::{NtpDuration, PollInterval, PollIntervalLimits};
+use crate::{
+    time_types::{NtpDuration, PollInterval, PollIntervalLimits},
+    AlgorithmConfig,
+};
 
 fn deserialize_option_accumulated_step_panic_threshold<'de, D>(
     deserializer: D,
@@ -260,6 +263,9 @@ pub struct SynchronizationConfig {
     /// synchronizing the clock
     #[serde(default = "default_local_stratum")]
     pub local_stratum: u8,
+
+    #[serde(default)]
+    pub algorithm: AlgorithmConfig,
 }
 
 impl Default for SynchronizationConfig {
@@ -272,6 +278,7 @@ impl Default for SynchronizationConfig {
             accumulated_step_panic_threshold: None,
 
             local_stratum: default_local_stratum(),
+            algorithm: Default::default(),
         }
     }
 }

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -29,7 +29,8 @@ pub(crate) mod exitcode {
 
 mod exports {
     pub use super::algorithm::{
-        DefaultTimeSyncController, ObservablePeerTimedata, StateUpdate, TimeSyncController,
+        AlgorithmConfig, KalmanClockController, ObservablePeerTimedata, StateUpdate,
+        TimeSyncController,
     };
     pub use super::clock::NtpClock;
     pub use super::config::{SourceDefaultsConfig, StepThreshold, SynchronizationConfig};

--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -3,9 +3,7 @@ mod server;
 pub mod subnet;
 
 use ntp_os_clock::DefaultNtpClock;
-use ntp_proto::{
-    DefaultTimeSyncController, SourceDefaultsConfig, SynchronizationConfig, TimeSyncController,
-};
+use ntp_proto::{SourceDefaultsConfig, SynchronizationConfig};
 use ntp_udp::{EnableTimestamps, InterfaceName};
 pub use peer::*;
 use serde::{Deserialize, Deserializer};
@@ -20,7 +18,7 @@ use thiserror::Error;
 use tokio::{fs::read_to_string, io};
 use tracing::{info, warn};
 
-use super::{spawn::PeerId, tracing::LogLevel};
+use super::tracing::LogLevel;
 
 const USAGE_MSG: &str = "\
 usage: ntp-daemon [-c PATH] [-l LOG_LEVEL]
@@ -246,18 +244,6 @@ pub struct ClockConfig {
     pub enable_timestamps: EnableTimestamps,
 }
 
-#[derive(Deserialize, Debug, Default, Clone, Copy)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct CombinedSynchronizationConfig {
-    #[serde(flatten)]
-    pub synchronization: SynchronizationConfig,
-    #[serde(flatten)]
-    pub algorithm: <DefaultTimeSyncController<DefaultNtpClock, PeerId> as TimeSyncController<
-        DefaultNtpClock,
-        PeerId,
-    >>::AlgorithmConfig,
-}
-
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LoggingObservabilityConfig {
@@ -279,7 +265,7 @@ pub struct Config {
     #[serde(rename = "nts-ke-server", default)]
     pub nts_ke: Vec<NtsKeConfig>,
     #[serde(default)]
-    pub synchronization: CombinedSynchronizationConfig,
+    pub synchronization: SynchronizationConfig,
     #[serde(default)]
     pub source_defaults: SourceDefaultsConfig,
     #[serde(default)]
@@ -380,12 +366,7 @@ impl Config {
             ok = false;
         }
 
-        if self.count_peers()
-            < self
-                .synchronization
-                .synchronization
-                .minimum_agreeing_sources
-        {
+        if self.count_peers() < self.synchronization.minimum_agreeing_sources {
             warn!("Fewer sources configured than are required to agree on the current time. Daemon will not change system time.");
             ok = false;
         }
@@ -489,19 +470,11 @@ mod tests {
             })]
         );
         assert_eq!(
-            config
-                .synchronization
-                .synchronization
-                .single_step_panic_threshold
-                .forward,
+            config.synchronization.single_step_panic_threshold.forward,
             Some(NtpDuration::from_seconds(0.))
         );
         assert_eq!(
-            config
-                .synchronization
-                .synchronization
-                .single_step_panic_threshold
-                .backward,
+            config.synchronization.single_step_panic_threshold.backward,
             Some(NtpDuration::from_seconds(0.))
         );
 
@@ -517,12 +490,10 @@ mod tests {
         );
         assert!(config
             .synchronization
-            .synchronization
             .single_step_panic_threshold
             .forward
             .is_none());
         assert!(config
-            .synchronization
             .synchronization
             .single_step_panic_threshold
             .backward

--- a/ntpd/src/daemon/peer.rs
+++ b/ntpd/src/daemon/peer.rs
@@ -7,7 +7,7 @@ use std::{
 
 use ntp_proto::{
     IgnoreReason, Measurement, NtpClock, NtpInstant, NtpTimestamp, Peer, PeerNtsData, PeerSnapshot,
-    PollError, ReferenceId, SourceDefaultsConfig, SystemSnapshot, Update,
+    PollError, ReferenceId, SourceDefaultsConfig, SynchronizationConfig, SystemSnapshot, Update,
 };
 use ntp_udp::{EnableTimestamps, InterfaceName, UdpSocket};
 use rand::{thread_rng, Rng};
@@ -15,7 +15,7 @@ use tracing::{debug, error, info, instrument, warn, Instrument, Span};
 
 use tokio::time::{Instant, Sleep};
 
-use super::{config::CombinedSynchronizationConfig, exitcode, spawn::PeerId};
+use super::{exitcode, spawn::PeerId};
 
 /// Trait needed to allow injecting of futures other than `tokio::time::Sleep` for testing
 pub trait Wait: Future<Output = ()> {
@@ -48,8 +48,7 @@ pub enum MsgForSystem {
 pub struct PeerChannels {
     pub msg_for_system_sender: tokio::sync::mpsc::Sender<MsgForSystem>,
     pub system_snapshot_receiver: tokio::sync::watch::Receiver<SystemSnapshot>,
-    pub synchronization_config_receiver:
-        tokio::sync::watch::Receiver<CombinedSynchronizationConfig>,
+    pub synchronization_config_receiver: tokio::sync::watch::Receiver<SynchronizationConfig>,
     pub source_defaults_config_receiver: tokio::sync::watch::Receiver<SourceDefaultsConfig>,
 }
 
@@ -567,7 +566,7 @@ mod tests {
 
         let (_, system_snapshot_receiver) = tokio::sync::watch::channel(SystemSnapshot::default());
         let (_, synchronization_config_receiver) =
-            tokio::sync::watch::channel(CombinedSynchronizationConfig::default());
+            tokio::sync::watch::channel(SynchronizationConfig::default());
         let (_, mut peer_defaults_config_receiver) =
             tokio::sync::watch::channel(SourceDefaultsConfig::default());
         let (msg_for_system_sender, msg_for_system_receiver) = mpsc::channel(1);


### PR DESCRIPTION
The algorithm section of the synchronization config was supposed to be separated out because the config values under it are not considered entirely stable, but the existing configuration merged the properties. It also meant that `deny_unknown_fields` was not working because that property [does not work](https://serde.rs/field-attrs.html#flatten) in combination with `flatten`, but this new setup no longer uses flatten here, so unknown fields will result in errors. I also cleaned up some of the type juggling, given that having a `DefaultAlgorithm` isn't really all that useful and only obfuscated the concrete types used.