### PR TITLE
Flatten observability config to allow deny_unknown_fields to work

### DIFF
--- a/ntpd/src/ctl.rs
+++ b/ntpd/src/ctl.rs
@@ -181,7 +181,6 @@ pub async fn main() -> std::io::Result<ExitCode> {
 
             let observation = config
                 .observability
-                .observe
                 .observation_path
                 .unwrap_or_else(|| PathBuf::from("/var/run/ntpd-rs/observe"));
 
@@ -316,7 +315,7 @@ mod tests {
     use std::path::Path;
 
     use crate::daemon::{
-        config::ObserveConfig,
+        config::ObservabilityConfig,
         sockets::{create_unix_socket_with_permissions, write_json},
     };
 
@@ -326,7 +325,7 @@ mod tests {
         command: Format,
         socket_name: &str,
     ) -> std::io::Result<Result<ExitCode, std::io::Error>> {
-        let config: ObserveConfig = Default::default();
+        let config: ObservabilityConfig = Default::default();
 
         // be careful with copying: tests run concurrently and should use a unique socket name!
         let path = std::env::temp_dir().join(socket_name);
@@ -384,7 +383,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_control_socket_peer_invalid_input() -> std::io::Result<()> {
-        let config: ObserveConfig = Default::default();
+        let config: ObservabilityConfig = Default::default();
 
         // be careful with copying: tests run concurrently and should use a unique socket name!
         let path = std::env::temp_dir().join("ntp-test-stream-10");

--- a/ntpd/src/daemon/mod.rs
+++ b/ntpd/src/daemon/mod.rs
@@ -115,7 +115,7 @@ async fn run(options: NtpDaemonOptions) -> Result<(), Box<dyn Error>> {
     }
 
     observer::spawn(
-        &config.observability.observe,
+        &config.observability,
         channels.peer_snapshots_receiver,
         channels.server_data_receiver,
         channels.system_snapshot_receiver,

--- a/ntpd/src/daemon/observer.rs
+++ b/ntpd/src/daemon/observer.rs
@@ -49,7 +49,7 @@ pub struct ObservedPeerState {
 }
 
 pub async fn spawn(
-    config: &super::config::ObserveConfig,
+    config: &super::config::ObservabilityConfig,
     peers_reader: tokio::sync::watch::Receiver<Vec<ObservablePeerState>>,
     server_reader: tokio::sync::watch::Receiver<Vec<ServerData>>,
     system_reader: tokio::sync::watch::Receiver<SystemSnapshot>,
@@ -66,7 +66,7 @@ pub async fn spawn(
 }
 
 async fn observer(
-    config: super::config::ObserveConfig,
+    config: super::config::ObservabilityConfig,
     peers_reader: tokio::sync::watch::Receiver<Vec<ObservablePeerState>>,
     server_reader: tokio::sync::watch::Receiver<Vec<ServerData>>,
     system_reader: tokio::sync::watch::Receiver<SystemSnapshot>,
@@ -160,7 +160,8 @@ mod tests {
     async fn test_observation() {
         // be careful with copying: tests run concurrently and should use a unique socket name!
         let path = std::env::temp_dir().join("ntp-test-stream-2");
-        let config = super::super::config::ObserveConfig {
+        let config = super::super::config::ObservabilityConfig {
+            log_level: None,
             observation_path: Some(path.clone()),
             observation_permissions: 0o700,
         };
@@ -223,7 +224,8 @@ mod tests {
     async fn test_block_during_read() {
         // be careful with copying: tests run concurrently and should use a unique socket name!
         let path = std::env::temp_dir().join("ntp-test-stream-3");
-        let config = super::super::config::ObserveConfig {
+        let config = super::super::config::ObservabilityConfig {
+            log_level: None,
             observation_path: Some(path.clone()),
             observation_permissions: 0o700,
         };

--- a/ntpd/src/metrics/exporter.rs
+++ b/ntpd/src/metrics/exporter.rs
@@ -151,7 +151,7 @@ async fn run(options: NtpMetricsExporterOptions) -> Result<(), Box<dyn std::erro
 
     let observation_socket_path = match options.observation_socket {
         Some(path) => path,
-        None => match config.observability.observe.observation_path {
+        None => match config.observability.observation_path {
             Some(path) => path,
             None => "/var/run/ntpd-rs/observe".into(),
         },


### PR DESCRIPTION
Using the serde `flatten` attribute in combination with `deny_unknown_fields` [does not work](https://serde.rs/field-attrs.html#flatten), so we flatten the struct in code instead.