### PR TITLE
Create deployment of docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,41 @@
+name: docs
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+
+      - name: Build site
+        run: utils/mkdocs.sh --no-bind-port build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c
+        with:
+          path: target/docs/site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@9dbe3824824f8a1377b8e298bafde1a50ede43e5

--- a/utils/mkdocs.sh
+++ b/utils/mkdocs.sh
@@ -8,4 +8,4 @@ if [ "$#" -gt 0 ]; then
     fi
 fi
 
-exec docker run --rm -it "${bind_port_arg[@]}" -v "${PWD}:/docs" -u "$(id -u):$(id -g)" squidfunk/mkdocs-material "$@"
+exec docker run --rm "${bind_port_arg[@]}" -v "${PWD}:/docs" -u "$(id -u):$(id -g)" squidfunk/mkdocs-material "$@"


### PR DESCRIPTION
This deploys the docs to https://docs.ntpd-rs.pendulum-project.org

Note: a previous version of this branch tested the deployment on this branch, but this was switched to only deploy on the main branch