### PR TITLE
Hide all the unused warnings when the internal-api feature is not enabled

### DIFF
--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -6,7 +6,6 @@
 //! Please visit the [ntpd-rs](https://github.com/pendulum-project/ntpd-rs) project
 //! for more information.
 #![forbid(unsafe_code)]
-
 #![cfg_attr(not(feature = "__internal-api"), allow(unused))]
 
 mod algorithm;

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -7,6 +7,8 @@
 //! for more information.
 #![forbid(unsafe_code)]
 
+#![cfg_attr(not(feature = "__internal-api"), allow(unused))]
+
 mod algorithm;
 mod clock;
 mod config;

--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "ntpd"
+readme = "README.md"
 description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
 publish.workspace = true
 rust-version.workspace = true
 


### PR DESCRIPTION
While packaging, rust spits out a lot of warnings of unused methods and structs because it does check the internal-api feature. This causes all those (invalid) warnings to hide. They will still show up as soon as you enable the internal-api feature, which it should be during normal ntpd-rs development.

Additionally, the readme from the ntpd crate now refers to the one inside the ntpd crate (which is just a symlink), but this prevents an additional warning.