### PR TITLE
Add dependency on ntpd-rs.service

### DIFF
--- a/docs/examples/conf/ntpd-rs-metrics.service
+++ b/docs/examples/conf/ntpd-rs-metrics.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Network Time Service (ntpd-rs) metrics exporter
 Documentation=https://github.com/pendulum-project/ntpd-rs
+After=ntpd-rs.service
+Wants=ntpd-rs.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Fixes #1120
This prevents ntpd-rs-metrics service failing to start on boot for me.