### PR TITLE
Refactor serve_packet into IO and non IO parts

### DIFF
--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -121,6 +121,12 @@ impl CipherProvider for Option<&dyn Cipher> {
     }
 }
 
+impl CipherProvider for Option<Box<dyn Cipher>> {
+    fn get(&self, _context: &[ExtensionField<'_>]) -> Option<CipherHolder<'_>> {
+        self.as_deref().map(CipherHolder::Other)
+    }
+}
+
 impl<C: Cipher> CipherProvider for C {
     fn get(&self, _context: &[ExtensionField<'_>]) -> Option<CipherHolder<'_>> {
         Some(CipherHolder::Other(self))

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -121,12 +121,6 @@ impl CipherProvider for Option<&dyn Cipher> {
     }
 }
 
-impl CipherProvider for Option<Box<dyn Cipher>> {
-    fn get(&self, _context: &[ExtensionField<'_>]) -> Option<CipherHolder<'_>> {
-        self.as_deref().map(CipherHolder::Other)
-    }
-}
-
 impl<C: Cipher> CipherProvider for C {
     fn get(&self, _context: &[ExtensionField<'_>]) -> Option<CipherHolder<'_>> {
         Some(CipherHolder::Other(self))

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -1108,18 +1108,14 @@ mod tests {
         let mut s = test_server();
         let mut resp_buf = [0; MAX_PACKET_SIZE];
 
-        let mut req_buf = [0; MAX_PACKET_SIZE];
         let (req, _) = NtpPacket::poll_message(PollInterval::default());
-        let mut buf = Cursor::new(req_buf.as_mut_slice());
-        req.serialize(&mut buf, &NoCipher).unwrap();
-        let end = buf.position() as usize;
-        let poll_packet = &req_buf[..end];
+        let req = serialize_packet_unencryped(&req);
 
         // No timestamp
         s.stats = ServerStats::default();
         assert_eq!(
             s.handle_packet(
-                poll_packet,
+                req.as_slice(),
                 &mut resp_buf,
                 "127.0.0.1:1337".parse().unwrap(),
                 None,

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -40,12 +40,12 @@ pub struct ServerStats {
 }
 
 impl ServerStats {
-    fn update_from(&self, res: &AcceptResult<'_>) {
+    fn update_from(&self, accept_result: &AcceptResult<'_>) {
         use AcceptResult::{Accept, CryptoNak, Deny, Ignore, RateLimit};
 
         self.received_packets.inc();
 
-        match res {
+        match accept_result {
             Accept { .. } => self.accepted_packets.inc(),
             Ignore => self.ignored_packets.inc(),
             Deny { .. } => self.denied_packets.inc(),
@@ -53,9 +53,9 @@ impl ServerStats {
             CryptoNak { .. } => self.nts_nak_packets.inc(),
         };
 
-        if res.is_nts() {
+        if accept_result.is_nts() {
             self.nts_received_packets.inc();
-            match res {
+            match accept_result {
                 Accept { .. } => self.nts_accepted_packets.inc(),
                 Deny { .. } => self.nts_denied_packets.inc(),
                 RateLimit { .. } => self.nts_rate_limited_packets.inc(),

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -1144,6 +1144,28 @@ mod tests {
         assert_eq!(s.stats.ignored_packets.get(), 1);
         assert_eq!(s.stats.received_packets.get(), 1);
     }
+
+    #[test]
+    fn invalid_packet() {
+        let mut s = test_server();
+        let mut resp_buf = [0; MAX_PACKET_SIZE];
+
+        let (req, _) = NtpPacket::poll_message(PollInterval::default());
+        let mut req = serialize_packet_unencryped(&req);
+        req[0] = 0;
+
+        assert!(s
+            .handle_packet(
+                &req,
+                &mut resp_buf,
+                "127.0.0.1:1337".parse().unwrap(),
+                Some(NtpTimestamp::default()),
+                s.config.rate_limiting_cutoff,
+            )
+            .is_none());
+        assert_eq!(s.stats.ignored_packets.get(), 1);
+        assert_eq!(s.stats.received_packets.get(), 1);
+    }
 }
 
 #[cfg(test)]

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -364,7 +364,8 @@ impl<C: 'static + NtpClock + Send> ServerTask<C> {
         }
     }
 
-    #[instrument(level = "debug", skip_all, fields(peer_addr, size = request_buf.len(), opt_timestamp))]
+    // TODO: this instrument breaks coverage collection for some reason...
+    // #[instrument(level = "debug", skip_all, fields(peer_addr, size = request_buf.len(), opt_timestamp))]
     fn handle_packet<'buf>(
         &mut self,
         request_buf: &[u8],

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -171,8 +171,8 @@ impl AcceptResult<'_> {
             AcceptResult::Accept { decoded_cookie, .. }
             | AcceptResult::Deny { decoded_cookie, .. }
             | AcceptResult::RateLimit { decoded_cookie, .. } => decoded_cookie.is_some(),
-            AcceptResult::CryptoNak { .. } => return true,
-            AcceptResult::Ignore => return false,
+            AcceptResult::CryptoNak { .. } => true,
+            AcceptResult::Ignore => false,
         }
     }
 }

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -364,7 +364,7 @@ impl<C: 'static + NtpClock + Send> ServerTask<C> {
         }
     }
 
-    #[tracing::instrument(skip_all, fields(peer_addr, size = request_buf.len(), opt_timestamp))]
+    #[instrument(level = "debug", skip_all, fields(peer_addr, size = request_buf.len(), opt_timestamp))]
     fn handle_packet<'buf>(
         &mut self,
         request_buf: &[u8],

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -59,9 +59,7 @@ impl ServerStats {
                 Accept { .. } => self.nts_accepted_packets.inc(),
                 Deny { .. } => self.nts_denied_packets.inc(),
                 RateLimit { .. } => self.nts_rate_limited_packets.inc(),
-                CryptoNak { .. } | Ignore => {
-                    0 /* counted above */
-                }
+                CryptoNak { .. } | Ignore => { /* counted above */ }
             };
         }
     }
@@ -73,8 +71,8 @@ pub struct Counter {
 }
 
 impl Counter {
-    fn inc(&self) -> u64 {
-        self.value.fetch_add(1, Ordering::Relaxed)
+    fn inc(&self) {
+        self.value.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn get(&self) -> u64 {


### PR DESCRIPTION
This decouples the IO during packet handling from the actual logic. This allows easier writing of tests,

This PR also flattens a lot of nested matches to make them more readable.