### PR TITLE
Add a 30 minute timeout to FreeBSD tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,6 +121,7 @@ jobs:
   # use https://github.com/vmactions/freebsd-vm for now
     name: test on freebsd
     runs-on: macos-12
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: test on freebsd


### PR DESCRIPTION
This detects boot loops earlier and thus wastes less resources. Also it makes noticing those loops faster (30 minutes instead of 6 hours)
