### PR TITLE
Fix minimum MAC size this fixes a deserialization error

### DIFF
--- a/ntp-proto/src/packet/extension_fields.rs
+++ b/ntp-proto/src/packet/extension_fields.rs
@@ -1254,48 +1254,6 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_without_cipher_invalid_length() {
-        // the message will be smaller than the cutoff value of 28
-        let cookie = ExtensionField::NtsCookie(Cow::Borrowed(&[0; 4]));
-
-        let data = ExtensionFieldData {
-            authenticated: vec![],
-            encrypted: vec![cookie],
-            untrusted: vec![],
-        };
-
-        let nonce_length = 11;
-        let cipher = crate::packet::crypto::IdentityCipher::new(nonce_length);
-
-        let mut w = [0u8; 128];
-        let mut cursor = Cursor::new(w.as_mut_slice());
-        data.serialize(&mut cursor, &cipher, ExtensionHeaderVersion::V4)
-            .unwrap();
-
-        let n = cursor.position() as usize;
-        let slice = &w.as_slice()[..n];
-
-        let cipher = crate::packet::crypto::NoCipher;
-
-        let result =
-            ExtensionFieldData::deserialize(slice, 0, &cipher, ExtensionHeaderVersion::V4).unwrap();
-
-        let DeserializedExtensionField {
-            efdata,
-            remaining_bytes,
-            cookie,
-        } = result;
-
-        assert_eq!(efdata.authenticated, &[]);
-        assert_eq!(efdata.encrypted, &[]);
-        assert_eq!(efdata.untrusted, &[]);
-
-        assert_eq!(remaining_bytes, slice);
-
-        assert!(cookie.is_none());
-    }
-
-    #[test]
     fn deserialize_without_cipher() {
         let cookie = ExtensionField::NtsCookie(Cow::Borrowed(&[0; 32]));
 

--- a/ntp-proto/src/packet/mac.rs
+++ b/ntp-proto/src/packet/mac.rs
@@ -9,7 +9,11 @@ pub(super) struct Mac<'a> {
 }
 
 impl<'a> Mac<'a> {
-    pub(super) const MAXIMUM_SIZE: usize = 28;
+    // As per RFC7822:
+    // If a MAC is used, it resides at the end of the packet.  This field
+    // can be either 24 octets long, 20 octets long, or a 4-octet
+    // crypto-NAK.
+    pub(super) const MAXIMUM_SIZE: usize = 24;
 
     pub(super) fn into_owned(self) -> Mac<'static> {
         Mac {


### PR DESCRIPTION
Before the last extension was always ignored if it was not at least 32 bytes without padding.