### PR TITLE
Replaced reference to non-existing CONFIGURATION.md

### DIFF
--- a/config/nts.client.toml
+++ b/config/nts.client.toml
@@ -3,7 +3,7 @@
 log-level = "info"
 observation-path = "/var/run/ntpd-rs/observe"
 
-# See CONFIGURATION.md for how to set up certificates
+# See https://docs.ntpd-rs.pendulum-project.org/man/ntp.toml.5/ on how to set up certificates
 [[source]]
 mode = "nts"
 address =  "localhost:4460"


### PR DESCRIPTION
There was a reference to the now non-existsting CONFIGURATION.md in the example client config file. Replaced it with a link to the relevant section of the documentation website. 