### PR TITLE
tokio error interest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rand = "0.8.0"
 arbitrary = { version = "1.0" }
 thiserror = "1.0.10"
 libc = "0.2.145"
-tokio = "1.28"
+tokio = "1.32"
 toml = ">=0.5.0,<0.8.0"
 async-trait = "0.1.22"
 


### PR DESCRIPTION
uses the tokio error interest to detect when the timestamp is (likely) available. Removes a bunch of our own unsafe code for this purpose.