### PR TITLE
Run tests with test keys symlinks from crate directories

### DIFF
--- a/ntp-proto/src/nts_record.rs
+++ b/ntp-proto/src/nts_record.rs
@@ -2103,17 +2103,16 @@ mod test {
 
     #[test]
     fn test_keyexchange_client() {
-        let cert_chain: Vec<rustls::Certificate> =
-            rustls_pemfile::certs(&mut std::io::BufReader::new(include_bytes!(
-                "../../test-keys/end.fullchain.pem"
-            ) as &[u8]))
-            .unwrap()
-            .into_iter()
-            .map(rustls::Certificate)
-            .collect();
+        let cert_chain: Vec<rustls::Certificate> = rustls_pemfile::certs(
+            &mut std::io::BufReader::new(include_bytes!("../test-keys/end.fullchain.pem") as &[u8]),
+        )
+        .unwrap()
+        .into_iter()
+        .map(rustls::Certificate)
+        .collect();
         let key_der = rustls::PrivateKey(
             rustls_pemfile::pkcs8_private_keys(&mut std::io::BufReader::new(include_bytes!(
-                "../../test-keys/end.key"
+                "../test-keys/end.key"
             )
                 as &[u8]))
             .unwrap()
@@ -2129,7 +2128,7 @@ mod test {
         let mut root_store = rustls::RootCertStore::empty();
         root_store.add_parsable_certificates(
             &rustls_pemfile::certs(&mut std::io::BufReader::new(include_bytes!(
-                "../../test-keys/testca.pem"
+                "../test-keys/testca.pem"
             ) as &[u8]))
             .unwrap(),
         );
@@ -2176,17 +2175,16 @@ mod test {
     }
 
     fn client_server_pair() -> (KeyExchangeClient, KeyExchangeServer) {
-        let cert_chain: Vec<rustls::Certificate> =
-            rustls_pemfile::certs(&mut std::io::BufReader::new(include_bytes!(
-                "../../test-keys/end.fullchain.pem"
-            ) as &[u8]))
-            .unwrap()
-            .into_iter()
-            .map(rustls::Certificate)
-            .collect();
+        let cert_chain: Vec<rustls::Certificate> = rustls_pemfile::certs(
+            &mut std::io::BufReader::new(include_bytes!("../test-keys/end.fullchain.pem") as &[u8]),
+        )
+        .unwrap()
+        .into_iter()
+        .map(rustls::Certificate)
+        .collect();
         let key_der = rustls::PrivateKey(
             rustls_pemfile::pkcs8_private_keys(&mut std::io::BufReader::new(include_bytes!(
-                "../../test-keys/end.key"
+                "../test-keys/end.key"
             )
                 as &[u8]))
             .unwrap()
@@ -2206,7 +2204,7 @@ mod test {
         let mut root_store = rustls::RootCertStore::empty();
         root_store.add_parsable_certificates(
             &rustls_pemfile::certs(&mut std::io::BufReader::new(include_bytes!(
-                "../../test-keys/testca.pem"
+                "../test-keys/testca.pem"
             ) as &[u8]))
             .unwrap(),
         );

--- a/ntp-proto/test-keys
+++ b/ntp-proto/test-keys
@@ -1,0 +1,1 @@
+../test-keys

--- a/ntpd/src/daemon/keyexchange.rs
+++ b/ntpd/src/daemon/keyexchange.rs
@@ -524,23 +524,23 @@ mod tests {
 
     #[test]
     fn parse_private_keys() {
-        let input = include_bytes!("../../../test-keys/end.key");
+        let input = include_bytes!("../../test-keys/end.key");
         let _ = private_key_from_bufread(input.as_slice()).unwrap().unwrap();
 
-        let input = include_bytes!("../../../test-keys/testca.key");
+        let input = include_bytes!("../../test-keys/testca.key");
         let _ = private_key_from_bufread(input.as_slice()).unwrap().unwrap();
 
         // openssl does no longer seem to want to generate this format
         // so we use https://github.com/rustls/pemfile/blob/main/tests/data/rsa1024.pkcs1.pem
-        let input = include_bytes!("../../../test-keys/rsa_key.pem");
+        let input = include_bytes!("../../test-keys/rsa_key.pem");
         let _ = private_key_from_bufread(input.as_slice()).unwrap().unwrap();
 
         // openssl ecparam -name prime256v1 -genkey -noout -out ec_key.pem
-        let input = include_bytes!("../../../test-keys/ec_key.pem");
+        let input = include_bytes!("../../test-keys/ec_key.pem");
         let _ = private_key_from_bufread(input.as_slice()).unwrap().unwrap();
 
         // openssl genpkey -algorithm EC -out pkcs8_key.pem -pkeyopt ec_paramgen_curve:prime256v1
-        let input = include_bytes!("../../../test-keys/pkcs8_key.pem");
+        let input = include_bytes!("../../test-keys/pkcs8_key.pem");
         let _ = private_key_from_bufread(input.as_slice()).unwrap().unwrap();
     }
 
@@ -551,8 +551,8 @@ mod tests {
 
         let (_sender, keyset) = tokio::sync::watch::channel(keyset);
         let nts_ke_config = NtsKeConfig {
-            certificate_chain_path: PathBuf::from("../test-keys/end.fullchain.pem"),
-            private_key_path: PathBuf::from("../test-keys/end.key"),
+            certificate_chain_path: PathBuf::from("test-keys/end.fullchain.pem"),
+            private_key_path: PathBuf::from("test-keys/end.key"),
             key_exchange_timeout_ms: 1000,
             listen: "0.0.0.0:5431".parse().unwrap(),
         };
@@ -562,7 +562,7 @@ mod tests {
         // give the server some time to make the port available
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        let ca = include_bytes!("../../../test-keys/testca.pem");
+        let ca = include_bytes!("../../test-keys/testca.pem");
         let result = key_exchange_client(
             "localhost".to_string(),
             5431,

--- a/ntpd/test-keys
+++ b/ntpd/test-keys
@@ -1,0 +1,1 @@
+../test-keys


### PR DESCRIPTION
The lib tests assumed that the entire repository is available, but once pushed to crates.io, only the crate itself is available. Cargo does resolve the symlink and pushes the target of that symlink to the repository though, so this should fix that.

Fixes #1214 
Fixes #1215 