### PR TITLE
Whitepaper changes

### DIFF
--- a/docs/algorithm/algorithm.tex
+++ b/docs/algorithm/algorithm.tex
@@ -24,7 +24,7 @@ This paper describes the approach used in ntpd-rs to go from the raw measurement
 
 \section{Prerequisites and notation}
 
-The rest of this paper assumes a comfort level with linear algebra to at least the level of calculating with matrices and vectors. We also assume basic knowledge of probability theory.
+The rest of this paper assumes a comfort level with linear algebra to at least the level of calculating with matrices and vectors. We also assume some knowledge of probability theory.
 
 In terms of notation, if $X$ is a random variable, we will denote its expectation value with $\E(X)$. We will denote the variance with $\Var(X) = \E((X-\E(X))^2)$, and if $Y$ is a second random variable, the covariance between $X$ and $Y$ will be denoted with $\Cov(X,Y) = \E((X-\E(X))(Y-\E(Y)))$.
 


### PR DESCRIPTION
Changed 'basic' to 'some' as it is perhaps a more fair assumption giving the content of the paper.

Also: Figure 3 seems rendered on top of page 10, which doesn't seem to be a logical place. It is defined in a different place in the .tex file. Am I looking at an old rendered PDF or is it a LaTeX thing?