### PR TITLE
Add length before sending observability messages over socket

### DIFF
--- a/ntpd/src/daemon/observer.rs
+++ b/ntpd/src/daemon/observer.rs
@@ -226,10 +226,10 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         let mut reader = UnixStream::connect(path).await.unwrap();
-
         let mut buf = vec![];
-        while reader.read_buf(&mut buf).await.unwrap() != 0 {}
-        let result: ObservableState = serde_json::from_slice(&buf).unwrap();
+        let result: ObservableState = crate::daemon::sockets::read_json(&mut reader, &mut buf)
+            .await
+            .unwrap();
 
         // Deal with randomized order
         assert_eq!(result.sources.len(), 1);

--- a/ntpd/tests/ctl.rs
+++ b/ntpd/tests/ctl.rs
@@ -61,6 +61,9 @@ fn test_status() {
 
     spawn(move || {
         let (mut stream, _) = socket.accept().unwrap();
+        stream
+            .write_all(&(EXAMPLE_SOCKET_OUTPUT.len() as u64).to_be_bytes())
+            .unwrap();
         stream.write_all(EXAMPLE_SOCKET_OUTPUT.as_bytes()).unwrap();
     });
 


### PR DESCRIPTION
Messages are now sent as `[u64_be length of message][message]` to allow us to know when the message is complete. This prevents any issues with larger messages from occuring.
 
Fixes #1495 