### PR TITLE
Run handling of observability on separate tokio tasks

### DIFF
--- a/ntpd/src/daemon/sockets.rs
+++ b/ntpd/src/daemon/sockets.rs
@@ -1,10 +1,9 @@
 use std::fs::Permissions;
 use std::path::Path;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-pub async fn write_json<T>(stream: &mut UnixStream, value: &T) -> std::io::Result<()>
+pub async fn write_json<T>(stream: &mut (impl AsyncWrite + Unpin), value: &T) -> std::io::Result<()>
 where
     T: serde::Serialize,
 {
@@ -14,7 +13,7 @@ where
 }
 
 pub async fn read_json<'a, T>(
-    stream: &mut UnixStream,
+    stream: &mut (impl AsyncRead + Unpin),
     buffer: &'a mut Vec<u8>,
 ) -> std::io::Result<T>
 where
@@ -85,7 +84,7 @@ fn create_unix_socket(path: &Path) -> std::io::Result<tokio::net::UnixListener> 
 
 #[cfg(test)]
 mod tests {
-    use tokio::net::UnixListener;
+    use tokio::net::{UnixListener, UnixStream};
 
     use super::*;
 


### PR DESCRIPTION
This should improve any concurrency issues that could happen while scraping metrics from our observability socket. I've tested this with a little siege test (`siege -b -t30S -c10 http://127.0.0.1:9975/metrics`) to check the throughput, before the change we had these numbers:

```json
{	"transactions":			      629647,
	"availability":			      100.00,
	"elapsed_time":			       29.80,
	"data_transferred":		     3063.39,
	"response_time":		        0.00,
	"transaction_rate":		    21129.09,
	"throughput":			      102.80,
	"concurrency":			        9.69,
	"successful_transactions":	      629647,
	"failed_transactions":		           0,
	"longest_transaction":		        0.01,
	"shortest_transaction":		        0.00
}
```

And after the change we get these numbers:
```json
{	"transactions":			     1051395,
	"availability":			      100.00,
	"elapsed_time":			       29.03,
	"data_transferred":		     5120.10,
	"response_time":		        0.00,
	"transaction_rate":		    36217.53,
	"throughput":			      176.37,
	"concurrency":			        9.41,
	"successful_transactions":	     1051395,
	"failed_transactions":		           0,
	"longest_transaction":		        0.02,
	"shortest_transaction":		        0.00
}
```

I'm not entirely sure this solves the issues experienced in #1497, given that the longest transaction time wasn't that long and we had no failures. But it at the very least it doesn't hurt. I expect the root cause of #1497 might also have to do something with the server doing something blocking (which I didn't test in my client-only ntpd-rs setup), but I'll have to explore a little further.