### PR TITLE
Remove support for the non-basic case for spawners

### DIFF
--- a/ntpd/src/daemon/spawn/nts.rs
+++ b/ntpd/src/daemon/spawn/nts.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 
 use super::super::{config::NtsSourceConfig, keyexchange::key_exchange_client};
 
-use super::{BasicSpawner, SourceId, SourceRemovedEvent, SpawnAction, SpawnEvent, SpawnerId};
+use super::{SourceId, SourceRemovedEvent, SpawnAction, SpawnEvent, Spawner, SpawnerId};
 
 pub struct NtsSpawner {
     config: NtsSourceConfig,
@@ -63,7 +63,7 @@ impl NtsSpawner {
 }
 
 #[async_trait::async_trait]
-impl BasicSpawner for NtsSpawner {
+impl Spawner for NtsSpawner {
     type Error = NtsSpawnError;
 
     async fn try_spawn(

--- a/ntpd/src/daemon/spawn/nts_pool.rs
+++ b/ntpd/src/daemon/spawn/nts_pool.rs
@@ -8,7 +8,7 @@ use super::super::{
     config::NtsPoolSourceConfig, keyexchange::key_exchange_client_with_denied_servers,
 };
 
-use super::{BasicSpawner, SourceId, SourceRemovedEvent, SpawnAction, SpawnEvent, SpawnerId};
+use super::{SourceId, SourceRemovedEvent, SpawnAction, SpawnEvent, Spawner, SpawnerId};
 
 use super::nts::resolve_addr;
 
@@ -62,7 +62,7 @@ impl NtsPoolSpawner {
 }
 
 #[async_trait::async_trait]
-impl BasicSpawner for NtsPoolSpawner {
+impl Spawner for NtsPoolSpawner {
     type Error = NtsPoolSpawnError;
 
     async fn try_spawn(

--- a/ntpd/src/daemon/spawn/pool.rs
+++ b/ntpd/src/daemon/spawn/pool.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 
 use super::super::config::PoolSourceConfig;
 
-use super::{BasicSpawner, SourceId, SourceRemovedEvent, SpawnAction, SpawnEvent, SpawnerId};
+use super::{SourceId, SourceRemovedEvent, SpawnAction, SpawnEvent, Spawner, SpawnerId};
 
 struct PoolSource {
     id: SourceId,
@@ -44,7 +44,7 @@ impl PoolSpawner {
 }
 
 #[async_trait::async_trait]
-impl BasicSpawner for PoolSpawner {
+impl Spawner for PoolSpawner {
     type Error = PoolSpawnError;
 
     async fn try_spawn(
@@ -132,8 +132,8 @@ mod tests {
     use crate::daemon::{
         config::{NormalizedAddress, PoolSourceConfig},
         spawn::{
-            pool::PoolSpawner, tests::get_create_params, BasicSpawner, SourceRemovalReason,
-            SourceRemovedEvent,
+            pool::PoolSpawner, tests::get_create_params, SourceRemovalReason, SourceRemovedEvent,
+            Spawner,
         },
         system::MESSAGE_BUFFER_SIZE,
     };

--- a/ntpd/src/daemon/spawn/standard.rs
+++ b/ntpd/src/daemon/spawn/standard.rs
@@ -8,8 +8,7 @@ use tracing::warn;
 use super::super::config::StandardSource;
 
 use super::{
-    BasicSpawner, SourceId, SourceRemovalReason, SourceRemovedEvent, SpawnAction, SpawnEvent,
-    SpawnerId,
+    SourceId, SourceRemovalReason, SourceRemovedEvent, SpawnAction, SpawnEvent, Spawner, SpawnerId,
 };
 
 pub struct StandardSpawner {
@@ -75,7 +74,7 @@ impl StandardSpawner {
 }
 
 #[async_trait::async_trait]
-impl BasicSpawner for StandardSpawner {
+impl Spawner for StandardSpawner {
     type Error = StandardSpawnError;
 
     async fn try_spawn(
@@ -139,8 +138,8 @@ mod tests {
     use crate::daemon::{
         config::{NormalizedAddress, StandardSource},
         spawn::{
-            standard::StandardSpawner, tests::get_create_params, BasicSpawner, SourceRemovalReason,
-            SourceRemovedEvent,
+            standard::StandardSpawner, tests::get_create_params, SourceRemovalReason,
+            SourceRemovedEvent, Spawner,
         },
         system::MESSAGE_BUFFER_SIZE,
     };

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -1,3 +1,5 @@
+use crate::daemon::spawn::spawner_task;
+
 #[cfg(feature = "unstable_nts-pool")]
 use super::spawn::nts_pool::NtsPoolSpawner;
 use super::{
@@ -260,7 +262,8 @@ impl<C: NtpClock + Sync, T: Wait> SystemTask<C, T> {
         debug!(id=?spawner_data.id, ty=spawner.get_description(), addr=spawner.get_addr_description(), "Running spawner");
         self.spawners.push(spawner_data);
         let spawn_tx = self.spawn_tx.clone();
-        tokio::spawn(async move { spawner.run(spawn_tx, notify_rx).await });
+        // tokio::spawn(async move { spawner.run(spawn_tx, notify_rx).await });
+        tokio::spawn(spawner_task(spawner, spawn_tx, notify_rx));
         Ok(id)
     }
 


### PR DESCRIPTION
Non-basic spawners are never used in our code. This removes the old Spawner trait and instead makes BasicSpawner the new Spawner trait. This allows us to always depend on the `try_spawn()` method to be available, which can be used for one-off spawning tasks (such as for the force-sync command). I believe that pretty much any future spawner could be implemented with this spawner setup anyway, even if a spawner needs direct control, it can just always return false for is_complete to do another round of spawning fairly quickly after any previous round.