### PR TITLE
Allow measurements without delay

### DIFF
--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -502,7 +502,7 @@ mod tests {
             noise += 1e-9;
 
             let message = source.handle_measurement(Measurement {
-                delay: NtpDuration::from_seconds(0.001 + noise),
+                delay: Some(NtpDuration::from_seconds(0.001 + noise)),
                 offset: NtpDuration::from_seconds(1700.0 + noise),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
@@ -712,7 +712,7 @@ mod tests {
             noise += 1e-9;
 
             let message = source.handle_measurement(Measurement {
-                delay: NtpDuration::from_seconds(0.001 + noise),
+                delay: Some(NtpDuration::from_seconds(0.001 + noise)),
                 offset: NtpDuration::from_seconds(1700.0 + noise),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
@@ -771,7 +771,7 @@ mod tests {
             noise *= -1.0;
 
             let message = source.handle_measurement(Measurement {
-                delay: NtpDuration::from_seconds(0.001 + noise),
+                delay: Some(NtpDuration::from_seconds(0.001 + noise)),
                 offset: NtpDuration::from_seconds(-3600.0 + noise),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,

--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -504,8 +504,6 @@ mod tests {
             let message = source.handle_measurement(Measurement {
                 delay: NtpDuration::from_seconds(0.001 + noise),
                 offset: NtpDuration::from_seconds(1700.0 + noise),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
 
@@ -716,8 +714,6 @@ mod tests {
             let message = source.handle_measurement(Measurement {
                 delay: NtpDuration::from_seconds(0.001 + noise),
                 offset: NtpDuration::from_seconds(1700.0 + noise),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
 
@@ -777,8 +773,6 @@ mod tests {
             let message = source.handle_measurement(Measurement {
                 delay: NtpDuration::from_seconds(0.001 + noise),
                 offset: NtpDuration::from_seconds(-3600.0 + noise),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
 

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -1,5 +1,3 @@
-use std::default;
-
 /// This module implements a kalman filter to filter the measurements
 /// provided by the sources.
 ///

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -73,7 +73,7 @@
 /// If they are often too small, v is quartered, and if they are often too
 /// large, v is quadrupled (note, this corresponds with doubling/halving
 /// the more intuitive standard deviation).
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 
 use crate::{
     algorithm::{KalmanControllerMessage, KalmanSourceMessage, SourceController},
@@ -288,7 +288,7 @@ impl MeasurementNoiseEstimator {
                 if let Some(delay) = delay {
                     stats.update(delay.to_seconds())
                 } else {
-                    error!("Could not update round-trip delay stats: delay is None")
+                    unreachable!("Could not update round-trip delay stats: delay is None")
                 }
             }
             Self::Constant(_v) => (),

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -569,10 +569,7 @@ impl SourceState {
         mut measurement: Measurement,
     ) -> bool {
         // preprocessing
-        measurement.delay = match measurement.delay {
-            Some(delay) => Some(delay.max(MIN_DELAY)),
-            None => None,
-        };
+        measurement.delay = measurement.delay.map(|delay| delay.max(MIN_DELAY));
 
         self.update_self_using_raw_measurement(source_defaults_config, algo_config, measurement)
     }

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -793,8 +793,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -813,8 +811,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(2800),
 
@@ -844,8 +840,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -865,8 +859,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(2800),
 
@@ -896,8 +888,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -917,8 +907,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(2800.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -953,8 +941,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -996,8 +982,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1028,8 +1012,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1079,8 +1061,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(-20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1111,8 +1091,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(-20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1167,8 +1145,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0.0),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1208,8 +1184,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0.0),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1279,8 +1253,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1305,8 +1277,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(1e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1331,8 +1301,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(2e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1357,8 +1325,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(3e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1383,8 +1349,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(4e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1409,8 +1373,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(5e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1435,8 +1397,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(6e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1461,8 +1421,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(7e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1508,8 +1466,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(4e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1534,8 +1490,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(5e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1560,8 +1514,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(6e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1586,8 +1538,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(7e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1613,8 +1563,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(4e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1639,8 +1587,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(5e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1665,8 +1611,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(6e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1691,8 +1635,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(7e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1751,8 +1693,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0.0),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1879,8 +1819,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0.0),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -278,6 +278,10 @@ pub enum MeasurementNoiseEstimator {
 }
 
 impl MeasurementNoiseEstimator {
+    pub fn new_roundtrip_delay() -> MeasurementNoiseEstimator {
+        MeasurementNoiseEstimator::RoundtripDelay(AveragingBuffer::default())
+    }
+
     fn update(&mut self, delay: Option<NtpDuration>) {
         match self {
             Self::RoundtripDelay(ref mut stats) => {
@@ -626,7 +630,7 @@ impl SourceState {
                     *self = SourceState(SourceStateInner::Initial(InitialSourceFilter {
                         noise_estimator: match filter.noise_estimator {
                             MeasurementNoiseEstimator::RoundtripDelay(_) => {
-                                MeasurementNoiseEstimator::RoundtripDelay(AveragingBuffer::default())
+                                MeasurementNoiseEstimator::new_roundtrip_delay()
                             }
                             MeasurementNoiseEstimator::Constant(v) => {
                                 MeasurementNoiseEstimator::Constant(v)
@@ -753,12 +757,11 @@ impl<SourceId: Copy> KalmanSourceController<SourceId> {
         index: SourceId,
         algo_config: AlgorithmConfig,
         source_defaults_config: SourceDefaultsConfig,
+        noise_estimator: MeasurementNoiseEstimator,
     ) -> Self {
         KalmanSourceController {
             index,
-            state: SourceState::new(MeasurementNoiseEstimator::RoundtripDelay(
-                AveragingBuffer::default(),
-            )),
+            state: SourceState::new(noise_estimator),
             algo_config,
             source_defaults_config,
         }

--- a/ntp-proto/src/algorithm/mod.rs
+++ b/ntp-proto/src/algorithm/mod.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, time::Duration};
 
+pub use kalman::MeasurementNoiseEstimator;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
@@ -72,7 +73,11 @@ pub trait TimeSyncController: Sized + Send + 'static {
     fn take_control(&mut self) -> Result<(), <Self::Clock as NtpClock>::Error>;
 
     /// Create a new source with given identity
-    fn add_source(&mut self, id: Self::SourceId) -> Self::SourceController;
+    fn add_source(
+        &mut self,
+        id: Self::SourceId,
+        noise_estimator: MeasurementNoiseEstimator,
+    ) -> Self::SourceController;
     /// Notify the controller that a previous source has gone
     fn remove_source(&mut self, id: Self::SourceId);
     /// Notify the controller that the status of a source (whether

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -39,8 +39,8 @@ pub(crate) mod exitcode {
 mod exports {
     pub use super::algorithm::{
         AlgorithmConfig, KalmanClockController, KalmanControllerMessage, KalmanSourceController,
-        KalmanSourceMessage, ObservableSourceTimedata, SourceController, StateUpdate,
-        TimeSyncController,
+        KalmanSourceMessage, MeasurementNoiseEstimator, ObservableSourceTimedata, SourceController,
+        StateUpdate, TimeSyncController,
     };
     pub use super::clock::NtpClock;
     pub use super::config::{SourceDefaultsConfig, StepThreshold, SynchronizationConfig};
@@ -72,6 +72,7 @@ mod exports {
         System, SystemAction, SystemActionIterator, SystemSnapshot, SystemSourceUpdate,
         TimeSnapshot,
     };
+
     #[cfg(feature = "__internal-fuzz")]
     pub use super::time_types::fuzz_duration_from_seconds;
     pub use super::time_types::{

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -38,8 +38,8 @@ pub(crate) mod exitcode {
 
 mod exports {
     pub use super::algorithm::{
-        AlgorithmConfig, KalmanClockController, KalmanControllerMessage, KalmanSourceController,
-        KalmanSourceMessage, MeasurementNoiseEstimator, ObservableSourceTimedata, SourceController,
+        AlgorithmConfig, AveragingBuffer, KalmanClockController, KalmanControllerMessage,
+        KalmanSourceController, KalmanSourceMessage, ObservableSourceTimedata, SourceController,
         StateUpdate, TimeSyncController,
     };
     pub use super::clock::NtpClock;

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -92,7 +92,7 @@ pub struct NtpSource<Controller: SourceController> {
 
 #[derive(Debug, Copy, Clone)]
 pub struct Measurement {
-    pub delay: NtpDuration,
+    pub delay: Option<NtpDuration>,
     pub offset: NtpDuration,
     pub localtime: NtpTimestamp,
     pub monotime: NtpInstant,
@@ -112,8 +112,10 @@ impl Measurement {
         local_clock_time: NtpInstant,
     ) -> Self {
         Self {
-            delay: ((recv_timestamp - send_timestamp)
-                - (packet.transmit_timestamp() - packet.receive_timestamp())),
+            delay: Some(
+                (recv_timestamp - send_timestamp)
+                    - (packet.transmit_timestamp() - packet.receive_timestamp()),
+            ),
             offset: ((packet.receive_timestamp() - send_timestamp)
                 + (packet.transmit_timestamp() - recv_timestamp))
                 / 2,
@@ -895,7 +897,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(0));
-        assert_eq!(result.delay, NtpDuration::from_fixed_int(2));
+        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(2)));
 
         packet.set_receive_timestamp(NtpTimestamp::from_fixed_int(2));
         packet.set_transmit_timestamp(NtpTimestamp::from_fixed_int(3));
@@ -906,7 +908,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(1));
-        assert_eq!(result.delay, NtpDuration::from_fixed_int(2));
+        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(2)));
 
         packet.set_receive_timestamp(NtpTimestamp::from_fixed_int(0));
         packet.set_transmit_timestamp(NtpTimestamp::from_fixed_int(5));
@@ -917,7 +919,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(1));
-        assert_eq!(result.delay, NtpDuration::from_fixed_int(-2));
+        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(-2)));
     }
 
     #[test]

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -94,8 +94,6 @@ pub struct NtpSource<Controller: SourceController> {
 pub struct Measurement {
     pub delay: NtpDuration,
     pub offset: NtpDuration,
-    pub transmit_timestamp: NtpTimestamp,
-    pub receive_timestamp: NtpTimestamp,
     pub localtime: NtpTimestamp,
     pub monotime: NtpInstant,
 
@@ -119,8 +117,6 @@ impl Measurement {
             offset: ((packet.receive_timestamp() - send_timestamp)
                 + (packet.transmit_timestamp() - recv_timestamp))
                 / 2,
-            transmit_timestamp: packet.transmit_timestamp(),
-            receive_timestamp: packet.receive_timestamp(),
             localtime: send_timestamp + (recv_timestamp - send_timestamp) / 2,
             monotime: local_clock_time,
 

--- a/ntpd/src/force_sync/algorithm.rs
+++ b/ntpd/src/force_sync/algorithm.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use ntp_proto::{
-    Measurement, NtpClock, NtpDuration, PollInterval, SourceController, TimeSyncController,
+    Measurement, MeasurementNoiseEstimator, NtpClock, NtpDuration, PollInterval, SourceController,
+    TimeSyncController,
 };
 use serde::Deserialize;
 
@@ -116,7 +117,11 @@ impl<C: NtpClock> TimeSyncController for SingleShotController<C> {
         Ok(())
     }
 
-    fn add_source(&mut self, _id: Self::SourceId) -> Self::SourceController {
+    fn add_source(
+        &mut self,
+        _id: Self::SourceId,
+        _noise_estimator: MeasurementNoiseEstimator,
+    ) -> Self::SourceController {
         SingleShotSourceController {
             min_poll_interval: self.min_poll_interval,
             done: false,


### PR DESCRIPTION
This PR allows the `delay` property of measurements to be either `NtpDuration` or `()`. If the delay is `()`, we use a constant value as the estimate of the measurement noise instead of an estimate based on the variance of delay values. This is useful for supporting alternative time sources, such as the SOCK protocol (#1632).