### PR TITLE
Add sock source for GPSD socket

### DIFF
--- a/docs/guide/gpsd-socket.md
+++ b/docs/guide/gpsd-socket.md
@@ -1,0 +1,28 @@
+# GPSd time source
+Instead of using another NTP server as a time source, it is also possible to use time data from [GPSd](https://gpsd.gitlab.io/gpsd/) as a time source for ntpd-rs.
+GPSd is able to interpret GPS signals from a GPS receiver, from which it can derive the current time.
+
+GPSd can be added as a time source for ntpd-rs by adding the following to the configuration:
+```toml
+[[source]]
+mode = "sock"
+path = "/run/chrony.ttyAMA0.sock"
+measurement_noise_estimate = 0.001
+```
+The `path` points to the location of the socket that GPSd writes timing data to. This socket was originally meant for chrony, but ntpd-rs also supports this same socket format. Here, `ttyAMA0` is the GPS receiver device used by GPSd.
+
+The `measurement_noise_estimate` gives a static estimate of how noisy GPSd's timing data is. Normally with NTP time sources, we would use the network delay as an independent estimate of how noisy the data is. When using GPSd as a time source, we do not have a good estimate of the noise, so we use a static noise estimate instead.
+
+## Setting up GPSd
+In order for GPSd to connect to ntpd-rs, GPSd must be started after ntpd-rs. This is because ntpd-rs needs to create the socket, and GPSd will only use the socket if it exists when it starts.
+
+GPSd can be manually restarted using:
+```sh
+sudo systemctl restart gpsd.socket
+```
+
+For help with setting up GPSd on e.g. a Raspberry Pi, see for example [this guide](https://n4bfr.com/2020/04/raspberry-pi-with-chrony/2/).
+
+## Pulse Per Second (PPS)
+Unfortunately, ntpd-rs does currently not yet support PPS timing data, but this may be added in the [future](https://github.com/pendulum-project/ntpd-rs/issues/882).
+Some challenges still need to be solved in order to support PPS data in the Kalman filters used for noise filtering.

--- a/docs/guide/gpsd-socket.md
+++ b/docs/guide/gpsd-socket.md
@@ -24,5 +24,5 @@ sudo systemctl restart gpsd.socket
 For help with setting up GPSd on e.g. a Raspberry Pi, see for example [this guide](https://n4bfr.com/2020/04/raspberry-pi-with-chrony/2/).
 
 ## Pulse Per Second (PPS)
-Unfortunately, ntpd-rs does currently not yet support PPS timing data, but this may be added in the [future](https://github.com/pendulum-project/ntpd-rs/issues/882).
+Ntpd-rs does currently not yet support PPS timing data, but this may be added in the [future](https://github.com/pendulum-project/ntpd-rs/issues/882).
 Some challenges still need to be solved in order to support PPS data in the Kalman filters used for noise filtering.

--- a/docs/includes/glossary.md
+++ b/docs/includes/glossary.md
@@ -8,3 +8,5 @@
 *[OS]: Operating System
 *[DNS]: Domain Name System
 *[CIDR]: Classless Inter-Domain Routing
+*[GPS]: Global Positioning System
+*[PPS]: Pulse Per Second

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
     - guide/getting-started.md
     - guide/installation.md
     - guide/server-setup.md
+    - guide/gpsd-socket.md
     - guide/exporting-metrics.md
     - guide/nts.md
     - guide/migrating-chrony.md

--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -347,7 +347,7 @@ impl<C: NtpClock, SourceId: Hash + Eq + Copy + Debug + Send + 'static> TimeSyncC
     type ControllerMessage = KalmanControllerMessage;
     type SourceMessage = KalmanSourceMessage<SourceId>;
     type NtpSourceController = TwoWayKalmanSourceController<SourceId>;
-    type SockSourceController = OneWayKalmanSourceController<SourceId>;
+    type OneWaySourceController = OneWayKalmanSourceController<SourceId>;
 
     fn new(
         clock: C,
@@ -387,11 +387,11 @@ impl<C: NtpClock, SourceId: Hash + Eq + Copy + Debug + Send + 'static> TimeSyncC
         )
     }
 
-    fn add_sock_source(
+    fn add_one_way_source(
         &mut self,
         id: SourceId,
         measurement_noise_estimate: f64,
-    ) -> Self::SockSourceController {
+    ) -> Self::OneWaySourceController {
         self.sources.insert(id, (None, false));
         KalmanSourceController::new(
             id,

--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -502,7 +502,7 @@ mod tests {
             noise += 1e-9;
 
             let message = source.handle_measurement(Measurement {
-                delay: NtpDuration::from_seconds(0.001 + noise),
+                delay: Some(NtpDuration::from_seconds(0.001 + noise)),
                 offset: NtpDuration::from_seconds(1700.0 + noise),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
@@ -712,7 +712,7 @@ mod tests {
             noise += 1e-9;
 
             let message = source.handle_measurement(Measurement {
-                delay: NtpDuration::from_seconds(0.001 + noise),
+                delay: Some(NtpDuration::from_seconds(0.001 + noise)),
                 offset: NtpDuration::from_seconds(1700.0 + noise),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
@@ -771,7 +771,7 @@ mod tests {
             noise *= -1.0;
 
             let message = source.handle_measurement(Measurement {
-                delay: NtpDuration::from_seconds(0.001 + noise),
+                delay: Some(NtpDuration::from_seconds(0.001 + noise)),
                 offset: NtpDuration::from_seconds(-3600.0 + noise),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,

--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -504,8 +504,6 @@ mod tests {
             let message = source.handle_measurement(Measurement {
                 delay: NtpDuration::from_seconds(0.001 + noise),
                 offset: NtpDuration::from_seconds(1700.0 + noise),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
 
@@ -716,8 +714,6 @@ mod tests {
             let message = source.handle_measurement(Measurement {
                 delay: NtpDuration::from_seconds(0.001 + noise),
                 offset: NtpDuration::from_seconds(1700.0 + noise),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
 
@@ -777,8 +773,6 @@ mod tests {
             let message = source.handle_measurement(Measurement {
                 delay: NtpDuration::from_seconds(0.001 + noise),
                 offset: NtpDuration::from_seconds(-3600.0 + noise),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: algo.clock.current_time,
                 monotime: cur_instant,
 

--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fmt::Debug, hash::Hash, time::Duration};
 
-pub use source::AveragingBuffer;
+pub(crate) use source::AveragingBuffer;
+use source::OneWayKalmanSourceController;
 use tracing::{debug, error, info};
 
 use crate::{
@@ -21,7 +22,7 @@ mod matrix;
 mod select;
 mod source;
 
-pub use source::KalmanSourceController;
+pub use source::{KalmanSourceController, TwoWayKalmanSourceController};
 
 fn sqr(x: f64) -> f64 {
     x * x
@@ -345,8 +346,8 @@ impl<C: NtpClock, SourceId: Hash + Eq + Copy + Debug + Send + 'static> TimeSyncC
     type AlgorithmConfig = AlgorithmConfig;
     type ControllerMessage = KalmanControllerMessage;
     type SourceMessage = KalmanSourceMessage<SourceId>;
-    type NtpSourceController = KalmanSourceController<SourceId, NtpDuration, AveragingBuffer>;
-    type SockSourceController = KalmanSourceController<SourceId, (), f64>;
+    type NtpSourceController = TwoWayKalmanSourceController<SourceId>;
+    type SockSourceController = OneWayKalmanSourceController<SourceId>;
 
     fn new(
         clock: C,

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -1,5 +1,3 @@
-use std::default;
-
 /// This module implements a kalman filter to filter the measurements
 /// provided by the sources.
 ///

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -73,7 +73,7 @@
 /// If they are often too small, v is quartered, and if they are often too
 /// large, v is quadrupled (note, this corresponds with doubling/halving
 /// the more intuitive standard deviation).
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 
 use crate::{
     algorithm::{KalmanControllerMessage, KalmanSourceMessage, SourceController},
@@ -288,7 +288,7 @@ impl MeasurementNoiseEstimator {
                 if let Some(delay) = delay {
                     stats.update(delay.to_seconds())
                 } else {
-                    error!("Could not update round-trip delay stats: delay is None")
+                    unreachable!("Could not update round-trip delay stats: delay is None")
                 }
             }
             Self::Constant(_v) => (),

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -569,10 +569,7 @@ impl SourceState {
         mut measurement: Measurement,
     ) -> bool {
         // preprocessing
-        measurement.delay = match measurement.delay {
-            Some(delay) => Some(delay.max(MIN_DELAY)),
-            None => None,
-        };
+        measurement.delay = measurement.delay.map(|delay| delay.max(MIN_DELAY));
 
         self.update_self_using_raw_measurement(source_defaults_config, algo_config, measurement)
     }

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -1030,8 +1030,13 @@ mod tests {
         assert!(matches!(source, SourceState(SourceStateInner::Stable(_))));
     }
 
-    #[test]
-    fn test_offset_steering_and_measurements() {
+    fn test_offset_steering_and_measurements<
+        D: Debug + Clone + Copy,
+        N: MeasurementNoiseEstimator<MeasurementDelay = D> + Clone,
+    >(
+        noise_estimator: N,
+        delay: D,
+    ) {
         let base = NtpTimestamp::from_fixed_int(0);
         let basei = NtpInstant::now();
         let mut source = SourceState(SourceStateInner::Stable(SourceFilter {
@@ -1041,15 +1046,12 @@ mod tests {
                 time: base,
             },
             clock_wander: 1e-8,
-            noise_estimator: AveragingBuffer {
-                data: [0.0, 0.0, 0.0, 0.0, 0.875e-6, 0.875e-6, 0.875e-6, 0.875e-6],
-                next_idx: 0,
-            },
+            noise_estimator: noise_estimator.clone(),
             precision_score: 0,
             poll_score: 0,
             desired_poll_interval: PollIntervalLimits::default().min,
             last_measurement: Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(20e-3),
                 localtime: base,
                 monotime: basei,
@@ -1082,15 +1084,12 @@ mod tests {
                 time: base,
             },
             clock_wander: 0.0,
-            noise_estimator: AveragingBuffer {
-                data: [0.0, 0.0, 0.0, 0.0, 0.875e-6, 0.875e-6, 0.875e-6, 0.875e-6],
-                next_idx: 0,
-            },
+            noise_estimator: noise_estimator.clone(),
             precision_score: 0,
             poll_score: 0,
             desired_poll_interval: PollIntervalLimits::default().min,
             last_measurement: Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(20e-3),
                 localtime: base,
                 monotime: basei,
@@ -1120,7 +1119,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(20e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1161,15 +1160,12 @@ mod tests {
                 time: base,
             },
             clock_wander: 0.0,
-            noise_estimator: AveragingBuffer {
-                data: [0.0, 0.0, 0.0, 0.0, 0.875e-6, 0.875e-6, 0.875e-6, 0.875e-6],
-                next_idx: 0,
-            },
+            noise_estimator: noise_estimator.clone(),
             precision_score: 0,
             poll_score: 0,
             desired_poll_interval: PollIntervalLimits::default().min,
             last_measurement: Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(-20e-3),
                 localtime: base,
                 monotime: basei,
@@ -1199,7 +1195,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(-20e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1235,7 +1231,29 @@ mod tests {
     }
 
     #[test]
+    fn test_offset_steering_and_measurements_normal() {
+        test_offset_steering_and_measurements(
+            AveragingBuffer {
+                data: [0.0, 0.0, 0.0, 0.0, 0.875e-6, 0.875e-6, 0.875e-6, 0.875e-6],
+                next_idx: 0,
+            },
+            NtpDuration::from_seconds(0.0),
+        );
+    }
+
+    #[test]
+    fn test_offset_steering_and_measurements_constant_noise_estimate() {
+        test_offset_steering_and_measurements(1e-9, ());
+    }
+
+    #[test]
     fn test_freq_steering() {
+        let noise_estimator = AveragingBuffer {
+            data: [0.0, 0.0, 0.0, 0.0, 0.875e-6, 0.875e-6, 0.875e-6, 0.875e-6],
+            next_idx: 0,
+        };
+        let delay = NtpDuration::from_seconds(0.0);
+
         let base = NtpTimestamp::from_fixed_int(0);
         let basei = NtpInstant::now();
         let mut source = SourceFilter {
@@ -1245,15 +1263,12 @@ mod tests {
                 time: base,
             },
             clock_wander: 1e-8,
-            noise_estimator: AveragingBuffer {
-                data: [0.0, 0.0, 0.0, 0.0, 0.875e-6, 0.875e-6, 0.875e-6, 0.875e-6],
-                next_idx: 0,
-            },
+            noise_estimator: noise_estimator.clone(),
             precision_score: 0,
             poll_score: 0,
             desired_poll_interval: PollIntervalLimits::default().min,
             last_measurement: Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(0.0),
                 localtime: base,
                 monotime: basei,
@@ -1284,15 +1299,12 @@ mod tests {
                 time: base,
             },
             clock_wander: 1e-8,
-            noise_estimator: AveragingBuffer {
-                data: [0.0, 0.0, 0.0, 0.0, 0.875e-6, 0.875e-6, 0.875e-6, 0.875e-6],
-                next_idx: 0,
-            },
+            noise_estimator: noise_estimator.clone(),
             precision_score: 0,
             poll_score: 0,
             desired_poll_interval: PollIntervalLimits::default().min,
             last_measurement: Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(0.0),
                 localtime: base,
                 monotime: basei,
@@ -1349,11 +1361,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_init() {
+    fn test_init<
+        D: Debug + Clone + Copy,
+        N: MeasurementNoiseEstimator<MeasurementDelay = D> + Clone,
+    >(
+        noise_estimator: N,
+        delay: D,
+    ) {
         let base = NtpTimestamp::from_fixed_int(0);
         let basei = NtpInstant::now();
-        let mut source = SourceState::new(AveragingBuffer::default());
+        let mut source = SourceState::new(noise_estimator);
         assert!(source
             .snapshot(0_usize, &AlgorithmConfig::default())
             .is_none());
@@ -1361,7 +1378,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(0e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1385,7 +1402,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(1e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1409,7 +1426,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(2e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1433,7 +1450,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(3e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1457,7 +1474,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(4e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1481,7 +1498,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(5e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1505,7 +1522,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(6e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1529,7 +1546,7 @@ mod tests {
             &SourceDefaultsConfig::default(),
             &AlgorithmConfig::default(),
             Measurement {
-                delay: NtpDuration::from_seconds(0.0),
+                delay,
                 offset: NtpDuration::from_seconds(7e-3),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
@@ -1560,6 +1577,22 @@ mod tests {
                 - 1e-6)
                 > 0.
         );
+    }
+
+    #[test]
+    fn test_init_normal() {
+        test_init(
+            AveragingBuffer {
+                data: [0.0, 0.0, 0.0, 0.0, 0.875e-6, 0.875e-6, 0.875e-6, 0.875e-6],
+                next_idx: 0,
+            },
+            NtpDuration::from_seconds(0.0),
+        );
+    }
+
+    #[test]
+    fn test_init_constant_noise_estimate() {
+        test_init(1e-3, ());
     }
 
     #[test]

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -793,8 +793,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -813,8 +811,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(2800),
 
@@ -844,8 +840,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -865,8 +859,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(2800),
 
@@ -896,8 +888,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -917,8 +907,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(2800.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -953,8 +941,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -996,8 +982,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1028,8 +1012,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1079,8 +1061,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(-20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1111,8 +1091,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(-20e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1167,8 +1145,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0.0),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1208,8 +1184,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0.0),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1279,8 +1253,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1305,8 +1277,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(1e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1331,8 +1301,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(2e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1357,8 +1325,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(3e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1383,8 +1349,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(4e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1409,8 +1373,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(5e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1435,8 +1397,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(6e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1461,8 +1421,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(7e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1508,8 +1466,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(4e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1534,8 +1490,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(5e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1560,8 +1514,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(6e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1586,8 +1538,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(7e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1613,8 +1563,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(4e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1639,8 +1587,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(5e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1665,8 +1611,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(6e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1691,8 +1635,6 @@ mod tests {
             Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(7e-3),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base + NtpDuration::from_seconds(1000.0),
                 monotime: basei + std::time::Duration::from_secs(1000),
 
@@ -1751,8 +1693,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0.0),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 
@@ -1879,8 +1819,6 @@ mod tests {
             last_measurement: Measurement {
                 delay: NtpDuration::from_seconds(0.0),
                 offset: NtpDuration::from_seconds(0.0),
-                transmit_timestamp: Default::default(),
-                receive_timestamp: Default::default(),
                 localtime: base,
                 monotime: basei,
 

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -278,6 +278,10 @@ pub enum MeasurementNoiseEstimator {
 }
 
 impl MeasurementNoiseEstimator {
+    pub fn new_roundtrip_delay() -> MeasurementNoiseEstimator {
+        MeasurementNoiseEstimator::RoundtripDelay(AveragingBuffer::default())
+    }
+
     fn update(&mut self, delay: Option<NtpDuration>) {
         match self {
             Self::RoundtripDelay(ref mut stats) => {
@@ -626,7 +630,7 @@ impl SourceState {
                     *self = SourceState(SourceStateInner::Initial(InitialSourceFilter {
                         noise_estimator: match filter.noise_estimator {
                             MeasurementNoiseEstimator::RoundtripDelay(_) => {
-                                MeasurementNoiseEstimator::RoundtripDelay(AveragingBuffer::default())
+                                MeasurementNoiseEstimator::new_roundtrip_delay()
                             }
                             MeasurementNoiseEstimator::Constant(v) => {
                                 MeasurementNoiseEstimator::Constant(v)
@@ -753,12 +757,11 @@ impl<SourceId: Copy> KalmanSourceController<SourceId> {
         index: SourceId,
         algo_config: AlgorithmConfig,
         source_defaults_config: SourceDefaultsConfig,
+        noise_estimator: MeasurementNoiseEstimator,
     ) -> Self {
         KalmanSourceController {
             index,
-            state: SourceState::new(MeasurementNoiseEstimator::RoundtripDelay(
-                AveragingBuffer::default(),
-            )),
+            state: SourceState::new(noise_estimator),
             algo_config,
             source_defaults_config,
         }

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -796,6 +796,11 @@ pub struct KalmanSourceController<
     source_defaults_config: SourceDefaultsConfig,
 }
 
+pub type TwoWayKalmanSourceController<SourceId> =
+    KalmanSourceController<SourceId, NtpDuration, AveragingBuffer>;
+
+pub type OneWayKalmanSourceController<SourceId> = KalmanSourceController<SourceId, (), f64>;
+
 impl<
         SourceId: Copy,
         D: Debug + Copy + Clone,

--- a/ntp-proto/src/algorithm/mod.rs
+++ b/ntp-proto/src/algorithm/mod.rs
@@ -60,7 +60,7 @@ pub trait TimeSyncController: Sized + Send + 'static {
         SourceMessage = Self::SourceMessage,
         MeasurementDelay = NtpDuration,
     >;
-    type SockSourceController: SourceController<
+    type OneWaySourceController: SourceController<
         ControllerMessage = Self::ControllerMessage,
         SourceMessage = Self::SourceMessage,
         MeasurementDelay = (),
@@ -79,12 +79,12 @@ pub trait TimeSyncController: Sized + Send + 'static {
 
     /// Create a new source with given identity
     fn add_source(&mut self, id: Self::SourceId) -> Self::NtpSourceController;
-    /// Create a new sock source with given identity
-    fn add_sock_source(
+    /// Create a new one way source with given identity (used e.g. with GPS sock sources)
+    fn add_one_way_source(
         &mut self,
         id: Self::SourceId,
         measurement_noise_estimate: f64,
-    ) -> Self::SockSourceController;
+    ) -> Self::OneWaySourceController;
     /// Notify the controller that a previous source has gone
     fn remove_source(&mut self, id: Self::SourceId);
     /// Notify the controller that the status of a source (whether
@@ -123,5 +123,5 @@ mod kalman;
 
 pub use kalman::{
     config::AlgorithmConfig, KalmanClockController, KalmanControllerMessage,
-    KalmanSourceController, TwoWayKalmanSourceController, KalmanSourceMessage,
+    KalmanSourceController, KalmanSourceMessage, TwoWayKalmanSourceController,
 };

--- a/ntp-proto/src/algorithm/mod.rs
+++ b/ntp-proto/src/algorithm/mod.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Debug, time::Duration};
 
-pub use kalman::AveragingBuffer;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
@@ -124,5 +123,5 @@ mod kalman;
 
 pub use kalman::{
     config::AlgorithmConfig, KalmanClockController, KalmanControllerMessage,
-    KalmanSourceController, KalmanSourceMessage,
+    KalmanSourceController, TwoWayKalmanSourceController, KalmanSourceMessage,
 };

--- a/ntp-proto/src/algorithm/mod.rs
+++ b/ntp-proto/src/algorithm/mod.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, time::Duration};
 
+pub use kalman::MeasurementNoiseEstimator;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
@@ -72,7 +73,11 @@ pub trait TimeSyncController: Sized + Send + 'static {
     fn take_control(&mut self) -> Result<(), <Self::Clock as NtpClock>::Error>;
 
     /// Create a new source with given identity
-    fn add_source(&mut self, id: Self::SourceId) -> Self::SourceController;
+    fn add_source(
+        &mut self,
+        id: Self::SourceId,
+        noise_estimator: MeasurementNoiseEstimator,
+    ) -> Self::SourceController;
     /// Notify the controller that a previous source has gone
     fn remove_source(&mut self, id: Self::SourceId);
     /// Notify the controller that the status of a source (whether

--- a/ntp-proto/src/identifiers.rs
+++ b/ntp-proto/src/identifiers.rs
@@ -12,6 +12,7 @@ impl ReferenceId {
     pub const KISS_RATE: ReferenceId = ReferenceId(u32::from_be_bytes(*b"RATE"));
     pub const KISS_RSTR: ReferenceId = ReferenceId(u32::from_be_bytes(*b"RSTR"));
     pub const NONE: ReferenceId = ReferenceId(u32::from_be_bytes(*b"XNON"));
+    pub const SOCK: ReferenceId = ReferenceId(u32::from_be_bytes(*b"SOCK"));
 
     // Network Time Security (NTS) negative-acknowledgment (NAK), from rfc8915
     pub const KISS_NTSN: ReferenceId = ReferenceId(u32::from_be_bytes(*b"NTSN"));

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -66,7 +66,7 @@ mod exports {
     pub use super::source::{
         AcceptSynchronizationError, Measurement, NtpSource, NtpSourceAction,
         NtpSourceActionIterator, NtpSourceSnapshot, NtpSourceUpdate, ObservableSourceState,
-        ProtocolVersion, Reach, SourceNtsData,
+        ProtocolVersion, Reach, SockSourceSnapshot, SockSourceUpdate, SourceNtsData,
     };
     pub use super::system::{
         System, SystemAction, SystemActionIterator, SystemSnapshot, SystemSourceUpdate,

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -66,7 +66,8 @@ mod exports {
     pub use super::source::{
         AcceptSynchronizationError, Measurement, NtpSource, NtpSourceAction,
         NtpSourceActionIterator, NtpSourceSnapshot, NtpSourceUpdate, ObservableSourceState,
-        ProtocolVersion, Reach, SockSource, SockSourceSnapshot, SockSourceUpdate, SourceNtsData,
+        OneWaySource, OneWaySourceSnapshot, OneWaySourceUpdate, ProtocolVersion, Reach,
+        SourceNtsData,
     };
     pub use super::system::{
         System, SystemAction, SystemActionIterator, SystemSnapshot, SystemSourceUpdate,

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -38,9 +38,9 @@ pub(crate) mod exitcode {
 
 mod exports {
     pub use super::algorithm::{
-        AlgorithmConfig, AveragingBuffer, KalmanClockController, KalmanControllerMessage,
-        KalmanSourceController, KalmanSourceMessage, ObservableSourceTimedata, SourceController,
-        StateUpdate, TimeSyncController,
+        AlgorithmConfig, KalmanClockController, KalmanControllerMessage, KalmanSourceController,
+        KalmanSourceMessage, ObservableSourceTimedata, SourceController, StateUpdate,
+        TimeSyncController, TwoWayKalmanSourceController,
     };
     pub use super::clock::NtpClock;
     pub use super::config::{SourceDefaultsConfig, StepThreshold, SynchronizationConfig};

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -39,8 +39,8 @@ pub(crate) mod exitcode {
 mod exports {
     pub use super::algorithm::{
         AlgorithmConfig, KalmanClockController, KalmanControllerMessage, KalmanSourceController,
-        KalmanSourceMessage, ObservableSourceTimedata, SourceController, StateUpdate,
-        TimeSyncController,
+        KalmanSourceMessage, MeasurementNoiseEstimator, ObservableSourceTimedata, SourceController,
+        StateUpdate, TimeSyncController,
     };
     pub use super::clock::NtpClock;
     pub use super::config::{SourceDefaultsConfig, StepThreshold, SynchronizationConfig};
@@ -72,6 +72,7 @@ mod exports {
         System, SystemAction, SystemActionIterator, SystemSnapshot, SystemSourceUpdate,
         TimeSnapshot,
     };
+
     #[cfg(feature = "__internal-fuzz")]
     pub use super::time_types::fuzz_duration_from_seconds;
     pub use super::time_types::{

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -66,7 +66,7 @@ mod exports {
     pub use super::source::{
         AcceptSynchronizationError, Measurement, NtpSource, NtpSourceAction,
         NtpSourceActionIterator, NtpSourceSnapshot, NtpSourceUpdate, ObservableSourceState,
-        ProtocolVersion, Reach, SockSourceSnapshot, SockSourceUpdate, SourceNtsData,
+        ProtocolVersion, Reach, SockSource, SockSourceSnapshot, SockSourceUpdate, SourceNtsData,
     };
     pub use super::system::{
         System, SystemAction, SystemActionIterator, SystemSnapshot, SystemSourceUpdate,

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -38,8 +38,8 @@ pub(crate) mod exitcode {
 
 mod exports {
     pub use super::algorithm::{
-        AlgorithmConfig, KalmanClockController, KalmanControllerMessage, KalmanSourceController,
-        KalmanSourceMessage, MeasurementNoiseEstimator, ObservableSourceTimedata, SourceController,
+        AlgorithmConfig, AveragingBuffer, KalmanClockController, KalmanControllerMessage,
+        KalmanSourceController, KalmanSourceMessage, ObservableSourceTimedata, SourceController,
         StateUpdate, TimeSyncController,
     };
     pub use super::clock::NtpClock;

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -92,6 +92,27 @@ pub struct NtpSource<Controller: SourceController<MeasurementDelay = NtpDuration
     bloom_filter: RemoteBloomFilter,
 }
 
+pub struct SockSource<Controller: SourceController<MeasurementDelay = ()>> {
+    controller: Controller,
+}
+
+impl<Controller: SourceController<MeasurementDelay = ()>> SockSource<Controller> {
+    pub(crate) fn new(controller: Controller) -> SockSource<Controller> {
+        SockSource { controller }
+    }
+
+    pub fn handle_measurement(
+        &mut self,
+        measurement: Measurement<()>,
+    ) -> Option<Controller::SourceMessage> {
+        self.controller.handle_measurement(measurement)
+    }
+
+    pub fn handle_message(&mut self, message: Controller::ControllerMessage) {
+        self.controller.handle_message(message)
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct Measurement<D: Debug + Copy + Clone> {
     pub delay: D,

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -92,13 +92,13 @@ pub struct NtpSource<Controller: SourceController<MeasurementDelay = NtpDuration
     bloom_filter: RemoteBloomFilter,
 }
 
-pub struct SockSource<Controller: SourceController<MeasurementDelay = ()>> {
+pub struct OneWaySource<Controller: SourceController<MeasurementDelay = ()>> {
     controller: Controller,
 }
 
-impl<Controller: SourceController<MeasurementDelay = ()>> SockSource<Controller> {
-    pub(crate) fn new(controller: Controller) -> SockSource<Controller> {
-        SockSource { controller }
+impl<Controller: SourceController<MeasurementDelay = ()>> OneWaySource<Controller> {
+    pub(crate) fn new(controller: Controller) -> OneWaySource<Controller> {
+        OneWaySource { controller }
     }
 
     pub fn handle_measurement(
@@ -200,8 +200,8 @@ impl Reach {
 }
 
 #[derive(Debug, Clone)]
-pub struct SockSourceUpdate<SourceMessage> {
-    pub snapshot: SockSourceSnapshot,
+pub struct OneWaySourceUpdate<SourceMessage> {
+    pub snapshot: OneWaySourceSnapshot,
     pub message: Option<SourceMessage>,
 }
 
@@ -209,11 +209,11 @@ pub struct SockSourceUpdate<SourceMessage> {
 #[allow(clippy::large_enum_variant)]
 pub enum SourceSnapshot {
     Ntp(NtpSourceSnapshot),
-    Sock(SockSourceSnapshot),
+    OneWay(OneWaySourceSnapshot),
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct SockSourceSnapshot {
+pub struct OneWaySourceSnapshot {
     pub source_id: ReferenceId,
     pub stratum: u8,
 }

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -178,6 +178,24 @@ impl Reach {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct SockSourceUpdate<SourceMessage> {
+    pub snapshot: SockSourceSnapshot,
+    pub message: Option<SourceMessage>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SourceSnapshot {
+    Ntp(NtpSourceSnapshot),
+    Sock(SockSourceSnapshot),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SockSourceSnapshot {
+    pub source_id: ReferenceId,
+    pub stratum: u8,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct NtpSourceSnapshot {
     pub source_addr: SocketAddr,

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -96,8 +96,6 @@ pub struct NtpSource<Controller: SourceController> {
 pub struct Measurement {
     pub delay: NtpDuration,
     pub offset: NtpDuration,
-    pub transmit_timestamp: NtpTimestamp,
-    pub receive_timestamp: NtpTimestamp,
     pub localtime: NtpTimestamp,
     pub monotime: NtpInstant,
 
@@ -121,8 +119,6 @@ impl Measurement {
             offset: ((packet.receive_timestamp() - send_timestamp)
                 + (packet.transmit_timestamp() - recv_timestamp))
                 / 2,
-            transmit_timestamp: packet.transmit_timestamp(),
-            receive_timestamp: packet.receive_timestamp(),
             localtime: send_timestamp + (recv_timestamp - send_timestamp) / 2,
             monotime: local_clock_time,
 

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -433,10 +433,11 @@ impl<Controller: SourceController<MeasurementDelay = NtpDuration>> NtpSource<Con
         source_defaults_config: SourceDefaultsConfig,
         protocol_version: ProtocolVersion,
         controller: Controller,
+        nts: Option<Box<SourceNtsData>>,
     ) -> (Self, NtpSourceActionIterator<Controller::SourceMessage>) {
         (
             Self {
-                nts: None,
+                nts,
 
                 last_poll_interval: source_defaults_config.poll_interval_limits.min,
                 remote_min_poll_interval: source_defaults_config.poll_interval_limits.min,
@@ -461,28 +462,6 @@ impl<Controller: SourceController<MeasurementDelay = NtpDuration>> NtpSource<Con
                 bloom_filter: RemoteBloomFilter::new(16).expect("16 is a valid chunk size"),
             },
             actions!(NtpSourceAction::SetTimer(Duration::from_secs(0))),
-        )
-    }
-
-    pub(crate) fn new_nts(
-        source_addr: SocketAddr,
-        source_defaults_config: SourceDefaultsConfig,
-        protocol_version: ProtocolVersion,
-        controller: Controller,
-        nts: Box<SourceNtsData>,
-    ) -> (Self, NtpSourceActionIterator<Controller::SourceMessage>) {
-        let (base, actions) = Self::new(
-            source_addr,
-            source_defaults_config,
-            protocol_version,
-            controller,
-        );
-        (
-            Self {
-                nts: Some(nts),
-                ..base
-            },
-            actions,
         )
     }
 

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -185,6 +185,7 @@ pub struct SockSourceUpdate<SourceMessage> {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::large_enum_variant)]
 pub enum SourceSnapshot {
     Ntp(NtpSourceSnapshot),
     Sock(SockSourceSnapshot),

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -94,7 +94,7 @@ pub struct NtpSource<Controller: SourceController> {
 
 #[derive(Debug, Copy, Clone)]
 pub struct Measurement {
-    pub delay: NtpDuration,
+    pub delay: Option<NtpDuration>,
     pub offset: NtpDuration,
     pub localtime: NtpTimestamp,
     pub monotime: NtpInstant,
@@ -114,8 +114,10 @@ impl Measurement {
         local_clock_time: NtpInstant,
     ) -> Self {
         Self {
-            delay: ((recv_timestamp - send_timestamp)
-                - (packet.transmit_timestamp() - packet.receive_timestamp())),
+            delay: Some(
+                (recv_timestamp - send_timestamp)
+                    - (packet.transmit_timestamp() - packet.receive_timestamp()),
+            ),
             offset: ((packet.receive_timestamp() - send_timestamp)
                 + (packet.transmit_timestamp() - recv_timestamp))
                 / 2,
@@ -913,7 +915,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(0));
-        assert_eq!(result.delay, NtpDuration::from_fixed_int(2));
+        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(2)));
 
         packet.set_receive_timestamp(NtpTimestamp::from_fixed_int(2));
         packet.set_transmit_timestamp(NtpTimestamp::from_fixed_int(3));
@@ -924,7 +926,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(1));
-        assert_eq!(result.delay, NtpDuration::from_fixed_int(2));
+        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(2)));
 
         packet.set_receive_timestamp(NtpTimestamp::from_fixed_int(0));
         packet.set_transmit_timestamp(NtpTimestamp::from_fixed_int(5));
@@ -935,7 +937,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(1));
-        assert_eq!(result.delay, NtpDuration::from_fixed_int(-2));
+        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(-2)));
     }
 
     #[test]

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -57,7 +57,7 @@ impl std::fmt::Debug for SourceNtsData {
 }
 
 #[derive(Debug)]
-pub struct NtpSource<Controller: SourceController> {
+pub struct NtpSource<Controller: SourceController<MeasurementDelay = NtpDuration>> {
     nts: Option<Box<SourceNtsData>>,
 
     // Poll interval used when sending last poll message.
@@ -93,8 +93,8 @@ pub struct NtpSource<Controller: SourceController> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct Measurement {
-    pub delay: Option<NtpDuration>,
+pub struct Measurement<D: Debug + Copy + Clone> {
+    pub delay: D,
     pub offset: NtpDuration,
     pub localtime: NtpTimestamp,
     pub monotime: NtpInstant,
@@ -106,7 +106,7 @@ pub struct Measurement {
     pub precision: i8,
 }
 
-impl Measurement {
+impl Measurement<NtpDuration> {
     fn from_packet(
         packet: &NtpPacket,
         send_timestamp: NtpTimestamp,
@@ -114,10 +114,8 @@ impl Measurement {
         local_clock_time: NtpInstant,
     ) -> Self {
         Self {
-            delay: Some(
-                (recv_timestamp - send_timestamp)
-                    - (packet.transmit_timestamp() - packet.receive_timestamp()),
-            ),
+            delay: (recv_timestamp - send_timestamp)
+                - (packet.transmit_timestamp() - packet.receive_timestamp()),
             offset: ((packet.receive_timestamp() - send_timestamp)
                 + (packet.transmit_timestamp() - recv_timestamp))
                 / 2,
@@ -248,7 +246,9 @@ impl NtpSourceSnapshot {
         Ok(())
     }
 
-    pub fn from_source<Controller: SourceController>(source: &NtpSource<Controller>) -> Self {
+    pub fn from_source<Controller: SourceController<MeasurementDelay = NtpDuration>>(
+        source: &NtpSource<Controller>,
+    ) -> Self {
         Self {
             source_addr: source.source_addr,
             source_id: source.source_id,
@@ -427,7 +427,7 @@ pub struct ObservableSourceState<SourceId> {
     pub id: SourceId,
 }
 
-impl<Controller: SourceController> NtpSource<Controller> {
+impl<Controller: SourceController<MeasurementDelay = NtpDuration>> NtpSource<Controller> {
     pub(crate) fn new(
         source_addr: SocketAddr,
         source_defaults_config: SourceDefaultsConfig,
@@ -882,12 +882,16 @@ mod test {
     impl SourceController for NoopController {
         type ControllerMessage = ();
         type SourceMessage = ();
+        type MeasurementDelay = NtpDuration;
 
         fn handle_message(&mut self, _: Self::ControllerMessage) {
             // do nothing
         }
 
-        fn handle_measurement(&mut self, _: Measurement) -> Option<Self::SourceMessage> {
+        fn handle_measurement(
+            &mut self,
+            _: Measurement<NtpDuration>,
+        ) -> Option<Self::SourceMessage> {
             // do nothing
             Some(())
         }
@@ -915,7 +919,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(0));
-        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(2)));
+        assert_eq!(result.delay, NtpDuration::from_fixed_int(2));
 
         packet.set_receive_timestamp(NtpTimestamp::from_fixed_int(2));
         packet.set_transmit_timestamp(NtpTimestamp::from_fixed_int(3));
@@ -926,7 +930,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(1));
-        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(2)));
+        assert_eq!(result.delay, NtpDuration::from_fixed_int(2));
 
         packet.set_receive_timestamp(NtpTimestamp::from_fixed_int(0));
         packet.set_transmit_timestamp(NtpTimestamp::from_fixed_int(5));
@@ -937,7 +941,7 @@ mod test {
             instant,
         );
         assert_eq!(result.offset, NtpDuration::from_fixed_int(1));
-        assert_eq!(result.delay, Some(NtpDuration::from_fixed_int(-2)));
+        assert_eq!(result.delay, NtpDuration::from_fixed_int(-2));
     }
 
     #[test]
@@ -1011,10 +1015,14 @@ mod test {
         impl SourceController for PollIntervalController {
             type ControllerMessage = ();
             type SourceMessage = ();
+            type MeasurementDelay = NtpDuration;
 
             fn handle_message(&mut self, _: Self::ControllerMessage) {}
 
-            fn handle_measurement(&mut self, _: Measurement) -> Option<Self::SourceMessage> {
+            fn handle_measurement(
+                &mut self,
+                _: Measurement<NtpDuration>,
+            ) -> Option<Self::SourceMessage> {
                 None
             }
 

--- a/ntp-proto/src/system.rs
+++ b/ntp-proto/src/system.rs
@@ -271,6 +271,7 @@ impl<SourceId: Hash + Eq + Copy + Debug, Controller: TimeSyncController<SourceId
         id: SourceId,
         source_addr: SocketAddr,
         protocol_version: ProtocolVersion,
+        nts: Option<Box<SourceNtsData>>,
     ) -> Result<
         (
             NtpSource<Controller::NtpSourceController>,
@@ -279,28 +280,6 @@ impl<SourceId: Hash + Eq + Copy + Debug, Controller: TimeSyncController<SourceId
         <Controller::Clock as NtpClock>::Error,
     > {
         Ok(NtpSource::new(
-            source_addr,
-            self.source_defaults_config,
-            protocol_version,
-            self.create_source_controller(id)?,
-        ))
-    }
-
-    #[allow(clippy::type_complexity)]
-    pub fn create_nts_source(
-        &mut self,
-        id: SourceId,
-        source_addr: SocketAddr,
-        protocol_version: ProtocolVersion,
-        nts: Box<SourceNtsData>,
-    ) -> Result<
-        (
-            NtpSource<Controller::NtpSourceController>,
-            NtpSourceActionIterator<Controller::SourceMessage>,
-        ),
-        <Controller::Clock as NtpClock>::Error,
-    > {
-        Ok(NtpSource::new_nts(
             source_addr,
             self.source_defaults_config,
             protocol_version,

--- a/ntp-proto/src/system.rs
+++ b/ntp-proto/src/system.rs
@@ -89,10 +89,12 @@ impl SystemSnapshot {
         {
             self.bloom_filter = BloomFilter::new();
             for source in used_sources {
-                if let Some(bf) = &source.bloom_filter {
-                    self.bloom_filter.add(bf);
-                } else if let ProtocolVersion::V5 = source.protocol_version {
-                    tracing::warn!("Using NTPv5 source without a bloom filter!");
+                if let SourceSnapshot::Ntp(source) = source {
+                    if let Some(bf) = &source.bloom_filter {
+                        self.bloom_filter.add(bf);
+                    } else if let ProtocolVersion::V5 = source.protocol_version {
+                        tracing::warn!("Using NTPv5 source without a bloom filter!");
+                    }
                 }
             }
             self.bloom_filter.add_id(&self.server_id);

--- a/ntp-proto/src/system.rs
+++ b/ntp-proto/src/system.rs
@@ -116,7 +116,7 @@ impl Default for SystemSnapshot {
 }
 
 pub struct SystemSourceUpdate<ControllerMessage> {
-    pub(crate) message: ControllerMessage,
+    pub message: ControllerMessage,
 }
 
 impl<ControllerMessage: Debug> std::fmt::Debug for SystemSourceUpdate<ControllerMessage> {

--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -476,6 +476,7 @@ impl Config {
 
         #[cfg(feature = "unstable_ntpv5")]
         if self.sources.iter().any(|config| match config {
+            NtpSourceConfig::Sock(_) => false,
             NtpSourceConfig::Standard(config) => matches!(config.ntp_version, Some(NtpVersion::V5)),
             NtpSourceConfig::Nts(config) => matches!(config.ntp_version, Some(NtpVersion::V5)),
             NtpSourceConfig::Pool(config) => matches!(config.ntp_version, Some(NtpVersion::V5)),

--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -444,6 +444,7 @@ impl Config {
                 NtpSourceConfig::Pool(config) => count += config.count,
                 #[cfg(feature = "unstable_nts-pool")]
                 NtpSourceConfig::NtsPool(config) => count += config.count,
+                NtpSourceConfig::Sock(_) => count += 1,
             }
         }
         count

--- a/ntpd/src/daemon/config/ntp_source.rs
+++ b/ntpd/src/daemon/config/ntp_source.rs
@@ -427,8 +427,8 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(test.source, NtpSourceConfig::Pool(_)));
+        assert_eq!(source_addr(&test.source), "example.com:123");
         if let NtpSourceConfig::Pool(config) = test.source {
-            assert_eq!(config.addr.to_string(), "example.com:123");
             assert_eq!(config.count, 4);
         }
 
@@ -442,8 +442,8 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(test.source, NtpSourceConfig::Pool(_)));
+        assert_eq!(source_addr(&test.source), "example.com:123");
         if let NtpSourceConfig::Pool(config) = test.source {
-            assert_eq!(config.addr.to_string(), "example.com:123");
             assert_eq!(config.count, 42);
         }
 
@@ -456,9 +456,7 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(test.source, NtpSourceConfig::Nts(_)));
-        if let NtpSourceConfig::Nts(config) = test.source {
-            assert_eq!(config.address.to_string(), "example.com:4460");
-        }
+        assert_eq!(source_addr(&test.source), "example.com:4460");
 
         #[cfg(feature = "unstable_nts-pool")]
         {
@@ -471,9 +469,7 @@ mod tests {
             )
             .unwrap();
             assert!(matches!(test.source, NtpSourceConfig::NtsPool(_)));
-            if let NtpSourceConfig::Nts(config) = test.source {
-                assert_eq!(config.address.to_string(), "example.com:4460");
-            }
+            assert_eq!(source_addr(&test.source), "example.com:4460");
         }
     }
 
@@ -499,9 +495,7 @@ mod tests {
         ))
         .unwrap();
         assert!(matches!(test.source, NtpSourceConfig::Nts(_)));
-        if let NtpSourceConfig::Nts(config) = test.source {
-            assert_eq!(config.address.to_string(), "example.com:4460");
-        }
+        assert_eq!(source_addr(&test.source), "example.com:4460");
     }
 
     #[test]

--- a/ntpd/src/daemon/config/ntp_source.rs
+++ b/ntpd/src/daemon/config/ntp_source.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use ntp_proto::NtpDuration;
 #[cfg(feature = "unstable_ntpv5")]
 use ntp_proto::NtpVersion;
 use rustls::pki_types::CertificateDer;
@@ -109,6 +110,13 @@ pub struct NtsPoolSourceConfig {
     pub ntp_version: Option<NtpVersion>,
 }
 
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct SockSourceConfig {
+    pub path: String,
+    pub measurement_noise_estimate: NtpDuration,
+}
+
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
 #[serde(tag = "mode")]
 pub enum NtpSourceConfig {
@@ -121,6 +129,8 @@ pub enum NtpSourceConfig {
     #[cfg(feature = "unstable_nts-pool")]
     #[serde(rename = "nts-pool")]
     NtsPool(NtsPoolSourceConfig),
+    #[serde(rename = "sock")]
+    Sock(SockSourceConfig),
 }
 
 /// A normalized address has a host and a port part. However, the host may be
@@ -364,6 +374,7 @@ mod tests {
             NtpSourceConfig::Pool(c) => c.addr.to_string(),
             #[cfg(feature = "unstable_nts-pool")]
             NtpSourceConfig::NtsPool(c) => c.addr.to_string(),
+            NtpSourceConfig::Sock(_c) => "".into(),
         }
     }
 

--- a/ntpd/src/daemon/config/ntp_source.rs
+++ b/ntpd/src/daemon/config/ntp_source.rs
@@ -374,7 +374,7 @@ mod tests {
             NtpSourceConfig::Pool(c) => c.addr.to_string(),
             #[cfg(feature = "unstable_nts-pool")]
             NtpSourceConfig::NtsPool(c) => c.addr.to_string(),
-            NtpSourceConfig::Sock(_c) => "".into(),
+            NtpSourceConfig::Sock(_c) => "".to_string(),
         }
     }
 

--- a/ntpd/src/daemon/mod.rs
+++ b/ntpd/src/daemon/mod.rs
@@ -6,6 +6,7 @@ mod ntp_source;
 pub mod nts_key_provider;
 pub mod observer;
 mod server;
+mod sock_source;
 pub mod sockets;
 pub mod spawn;
 mod system;

--- a/ntpd/src/daemon/ntp_source.rs
+++ b/ntpd/src/daemon/ntp_source.rs
@@ -4,7 +4,7 @@ use std::{
 
 use ntp_proto::{
     NtpClock, NtpDuration, NtpInstant, NtpSource, NtpSourceActionIterator, NtpSourceUpdate,
-    NtpTimestamp, ObservableSourceState, SockSourceUpdate, SourceController, SystemSourceUpdate,
+    NtpTimestamp, ObservableSourceState, OneWaySourceUpdate, SourceController, SystemSourceUpdate,
 };
 #[cfg(target_os = "linux")]
 use timestamped_socket::socket::open_interface_udp;
@@ -41,7 +41,7 @@ pub enum MsgForSystem<SourceMessage> {
     /// Update from source
     SourceUpdate(SourceId, NtpSourceUpdate<SourceMessage>),
     /// Update from sock source
-    SockSourceUpdate(SourceId, SockSourceUpdate<SourceMessage>),
+    OneWaySourceUpdate(SourceId, OneWaySourceUpdate<SourceMessage>),
 }
 
 #[derive(Debug)]

--- a/ntpd/src/daemon/ntp_source.rs
+++ b/ntpd/src/daemon/ntp_source.rs
@@ -451,10 +451,9 @@ mod tests {
     };
 
     use ntp_proto::{
-        AlgorithmConfig, AveragingBuffer, KalmanClockController, KalmanControllerMessage,
-        KalmanSourceController, KalmanSourceMessage, NoCipher, NtpDuration, NtpLeapIndicator,
-        NtpPacket, ProtocolVersion, SourceDefaultsConfig, SynchronizationConfig, SystemSnapshot,
-        TimeSnapshot,
+        AlgorithmConfig, KalmanClockController, KalmanControllerMessage, KalmanSourceMessage,
+        NoCipher, NtpDuration, NtpLeapIndicator, NtpPacket, ProtocolVersion, SourceDefaultsConfig,
+        SynchronizationConfig, SystemSnapshot, TimeSnapshot, TwoWayKalmanSourceController,
     };
     use timestamped_socket::socket::{open_ip, GeneralTimestampMode, Open};
     use tokio::sync::{broadcast, mpsc};
@@ -583,7 +582,7 @@ mod tests {
     async fn test_startup<T: Wait>(
         port_base: u16,
     ) -> (
-        SourceTask<TestClock, KalmanSourceController<SourceId, NtpDuration, AveragingBuffer>, T>,
+        SourceTask<TestClock, TwoWayKalmanSourceController<SourceId>, T>,
         Socket<SocketAddr, Open>,
         mpsc::Receiver<MsgForSystem<KalmanSourceMessage<SourceId>>>,
         broadcast::Sender<SystemSourceUpdate<KalmanControllerMessage>>,

--- a/ntpd/src/daemon/ntp_source.rs
+++ b/ntpd/src/daemon/ntp_source.rs
@@ -611,6 +611,7 @@ mod tests {
             index,
             SocketAddr::from((Ipv4Addr::LOCALHOST, port_base)),
             ProtocolVersion::default(),
+            None,
         ) else {
             panic!("Could not create test source");
         };

--- a/ntpd/src/daemon/ntp_source.rs
+++ b/ntpd/src/daemon/ntp_source.rs
@@ -4,7 +4,7 @@ use std::{
 
 use ntp_proto::{
     NtpClock, NtpDuration, NtpInstant, NtpSource, NtpSourceActionIterator, NtpSourceUpdate,
-    NtpTimestamp, ObservableSourceState, SourceController, SystemSourceUpdate,
+    NtpTimestamp, ObservableSourceState, SockSourceUpdate, SourceController, SystemSourceUpdate,
 };
 #[cfg(target_os = "linux")]
 use timestamped_socket::socket::open_interface_udp;
@@ -40,6 +40,8 @@ pub enum MsgForSystem<SourceMessage> {
     Unreachable(SourceId),
     /// Update from source
     SourceUpdate(SourceId, NtpSourceUpdate<SourceMessage>),
+    /// Update from sock source
+    SockSourceUpdate(SourceId, SockSourceUpdate<SourceMessage>),
 }
 
 #[derive(Debug)]

--- a/ntpd/src/daemon/sock_source.rs
+++ b/ntpd/src/daemon/sock_source.rs
@@ -5,7 +5,6 @@ use ntp_proto::{
     SockSourceSnapshot, SockSourceUpdate, SourceController, SystemSourceUpdate,
 };
 use tracing::debug;
-#[cfg(target_os = "linux")]
 use tracing::{error, instrument, Instrument, Span};
 
 use tokio::net::UnixDatagram;

--- a/ntpd/src/daemon/sock_source.rs
+++ b/ntpd/src/daemon/sock_source.rs
@@ -1,50 +1,80 @@
 use std::{marker::PhantomData, pin::Pin, time::Duration};
 
-use ntp_proto::NtpClock;
+use ntp_proto::{
+    Measurement, NtpClock, NtpDuration, NtpInstant, NtpLeapIndicator, SourceController,
+};
 #[cfg(target_os = "linux")]
-use timestamped_socket::interface::InterfaceName;
-use tracing::{info, instrument, Instrument, Span};
+use tracing::{error, info, instrument, Instrument, Span};
 
 use tokio::time::{Instant, Sleep};
 
-use super::{ntp_source::Wait, spawn::SourceId};
+use crate::daemon::exitcode;
 
-pub(crate) struct SockSourceTask<C: 'static + NtpClock + Send, T: Wait> {
+use super::ntp_source::Wait;
+
+pub(crate) struct SockSourceTask<
+    C: 'static + NtpClock + Send,
+    Controller: SourceController,
+    T: Wait,
+> {
     _wait: PhantomData<T>,
-    index: SourceId,
+    socket_path: String,
     clock: C,
-    interface: Option<InterfaceName>,
-    name: String,
+    controller: Controller,
 }
 
-impl<C, T> SockSourceTask<C, T>
+impl<C, Controller: SourceController, T> SockSourceTask<C, Controller, T>
 where
     C: 'static + NtpClock + Send + Sync,
     T: Wait,
 {
     async fn run(&mut self, mut poll_wait: Pin<&mut T>) {
+        let mut delta: f64 = 0.; // temporary offset just to experiment
         loop {
             // temporary: prints "sock!" every second
-            info!("sock!");
+            info!("sock! {}", self.socket_path);
             poll_wait
                 .as_mut()
                 .reset(Instant::now() + Duration::from_secs(1));
             poll_wait.as_mut().await;
+
+            delta += 1.;
+            let time = match self.clock.now() {
+                Ok(time) => time,
+                Err(e) => {
+                    error!(error = ?e, "There was an error retrieving the current time");
+                    std::process::exit(exitcode::NOPERM);
+                }
+            };
+
+            let measurement = Measurement {
+                delay: None,
+                offset: NtpDuration::from_seconds(delta), // TODO: get from socket
+                localtime: time,                          // TODO: use tv from socket?
+                monotime: NtpInstant::now(),
+
+                stratum: 1,
+                root_delay: NtpDuration::ZERO,
+                root_dispersion: NtpDuration::ZERO,
+                leap: NtpLeapIndicator::NoWarning, // TODO: get from socket
+                precision: 1,                      // TODO: compute on startup?
+            };
+            let controller_message = self.controller.handle_measurement(measurement);
+            println!("{:?}", controller_message); // TODO: handle controller message
         }
     }
 }
 
-impl<C> SockSourceTask<C, Sleep>
+impl<C, Controller: SourceController> SockSourceTask<C, Controller, Sleep>
 where
     C: 'static + NtpClock + Send + Sync,
 {
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = tracing::Level::ERROR, name = "Ntp Source", skip(clock))]
+    #[instrument(level = tracing::Level::ERROR, name = "Ntp Source", skip(clock, controller))]
     pub fn spawn(
-        index: SourceId,
-        name: String,
-        interface: Option<InterfaceName>,
+        socket_path: String,
         clock: C,
+        controller: Controller,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(
             (async move {
@@ -53,10 +83,9 @@ where
 
                 let mut process = SockSourceTask {
                     _wait: PhantomData,
-                    index,
-                    name,
+                    socket_path,
                     clock,
-                    interface,
+                    controller,
                 };
 
                 process.run(poll_wait).await;

--- a/ntpd/src/daemon/sock_source.rs
+++ b/ntpd/src/daemon/sock_source.rs
@@ -1,8 +1,8 @@
-use std::{array::TryFromSliceError, path::Path};
+use std::{fmt::Display, path::Path};
 
 use ntp_proto::{
     Measurement, NtpClock, NtpDuration, NtpInstant, NtpLeapIndicator, ReferenceId,
-    SockSourceSnapshot, SockSourceUpdate, SourceController,
+    SockSourceSnapshot, SockSourceUpdate, SourceController, SystemSourceUpdate,
 };
 use tracing::debug;
 #[cfg(target_os = "linux")]
@@ -14,6 +14,7 @@ use crate::daemon::{exitcode, ntp_source::MsgForSystem};
 
 use super::{ntp_source::SourceChannels, spawn::SourceId};
 
+// Based on https://gitlab.com/gpsd/gpsd/-/blob/master/gpsd/timehint.c#L268
 #[derive(Debug)]
 struct SockSample {
     // tv_sec: i64,
@@ -24,19 +25,58 @@ struct SockSample {
     magic: i32,
 }
 
-// Based on https://gitlab.com/gpsd/gpsd/-/blob/master/gpsd/timehint.c#L268
 const SOCK_MAGIC: i32 = 0x534f434b;
 const SOCK_SAMPLE_SIZE: usize = 40;
-fn deserialize_sample(buf: [u8; SOCK_SAMPLE_SIZE]) -> Result<SockSample, TryFromSliceError> {
-    Ok(SockSample {
+
+#[derive(Debug)]
+enum SampleError {
+    IOError(std::io::Error),
+    SliceError(std::array::TryFromSliceError),
+    WrongSize(usize),
+    WrongMagic(i32),
+    WrongPulse(i32),
+}
+
+impl Display for SampleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SampleError::IOError(e) => f.write_str(&e.to_string()),
+            SampleError::SliceError(e) => f.write_str(&e.to_string()),
+            SampleError::WrongSize(s) => f.write_fmt(format_args!("Invalid size {s}")),
+            SampleError::WrongMagic(m) => f.write_fmt(format_args!("Invalid magic {m}")),
+            SampleError::WrongPulse(p) => f.write_fmt(format_args!("Invalid pulse {p}")),
+        }
+    }
+}
+
+fn deserialize_sample(
+    result: Result<usize, std::io::Error>,
+    buf: [u8; SOCK_SAMPLE_SIZE],
+) -> Result<SockSample, SampleError> {
+    let size = result.map_err(SampleError::IOError)?;
+    if size != SOCK_SAMPLE_SIZE {
+        return Err(SampleError::WrongSize(size));
+    }
+
+    let sample = SockSample {
         // tv_sec: i64::from_le_bytes(buf[0..8].try_into()?),
         // tv_usec: i64::from_le_bytes(buf[8..16].try_into()?),
-        offset: f64::from_le_bytes(buf[16..24].try_into()?),
-        pulse: i32::from_le_bytes(buf[24..28].try_into()?),
-        leap: i32::from_le_bytes(buf[28..32].try_into()?),
+        offset: f64::from_le_bytes(buf[16..24].try_into().map_err(SampleError::SliceError)?),
+        pulse: i32::from_le_bytes(buf[24..28].try_into().map_err(SampleError::SliceError)?),
+        leap: i32::from_le_bytes(buf[28..32].try_into().map_err(SampleError::SliceError)?),
         // skip padding (4 bytes)
-        magic: i32::from_le_bytes(buf[36..40].try_into()?),
-    })
+        magic: i32::from_le_bytes(buf[36..40].try_into().map_err(SampleError::SliceError)?),
+    };
+
+    if sample.magic != SOCK_MAGIC {
+        return Err(SampleError::WrongMagic(sample.magic));
+    }
+
+    if sample.pulse != 0 {
+        return Err(SampleError::WrongPulse(sample.pulse));
+    }
+
+    Ok(sample)
 }
 
 pub(crate) struct SockSourceTask<C: 'static + NtpClock + Send, Controller: SourceController> {
@@ -64,75 +104,88 @@ where
 {
     async fn run(&mut self) {
         loop {
-            let mut data = [0; SOCK_SAMPLE_SIZE];
-            match self.socket.recv(&mut data).await {
-                Ok(_) => (),
-                Err(e) => {
-                    error!("Error receiving data from socket: {:?}", e);
-                    continue;
-                }
-            }
-            let sample = match deserialize_sample(data) {
-                Ok(s) => s,
-                Err(e) => {
-                    error!("Error deserializing sample: {:?}", e);
-                    continue;
-                }
-            };
-            debug!("received {:?}", sample);
+            let mut buf = [0; SOCK_SAMPLE_SIZE];
 
-            if sample.magic != SOCK_MAGIC {
-                error!("Incorrect sock magic: {}", sample.magic);
-                continue;
+            enum SelectResult<Controller: SourceController> {
+                SockRecv(Result<usize, std::io::Error>),
+                SystemUpdate(
+                    Result<
+                        SystemSourceUpdate<Controller::ControllerMessage>,
+                        tokio::sync::broadcast::error::RecvError,
+                    >,
+                ),
             }
 
-            if sample.pulse != 0 {
-                error!("Socket sample indicates PPS: {}", sample.pulse);
-                continue;
-            }
-
-            let leap = match sample.leap {
-                0 => NtpLeapIndicator::NoWarning,
-                1 => NtpLeapIndicator::Leap61,
-                2 => NtpLeapIndicator::Leap59,
-                _ => NtpLeapIndicator::Unknown,
-            };
-
-            let time = match self.clock.now() {
-                Ok(time) => time,
-                Err(e) => {
-                    error!(error = ?e, "There was an error retrieving the current time");
-                    std::process::exit(exitcode::NOPERM);
-                }
-            };
-
-            let measurement = Measurement {
-                delay: (),
-                offset: NtpDuration::from_seconds(sample.offset),
-                localtime: time,
-                monotime: NtpInstant::now(),
-
-                stratum: 0,
-                root_delay: NtpDuration::ZERO,
-                root_dispersion: NtpDuration::ZERO,
-                leap,
-                precision: 0, // TODO: compute on startup?
-            };
-
-            let controller_message = self.controller.handle_measurement(measurement);
-
-            let update = SockSourceUpdate {
-                snapshot: SockSourceSnapshot {
-                    source_id: ReferenceId::SOCK,
-                    stratum: 0,
+            let selected: SelectResult<Controller> = tokio::select! {
+                result = self.socket.recv(&mut buf) => {
+                    SelectResult::SockRecv(result)
                 },
-                message: controller_message,
+                result = self.channels.system_update_receiver.recv() => {
+                    SelectResult::SystemUpdate(result)
+                }
             };
-            self.channels
-                .msg_for_system_sender
-                .send(MsgForSystem::SockSourceUpdate(self.index, update))
-                .await
-                .ok();
+
+            match selected {
+                SelectResult::SockRecv(result) => match deserialize_sample(result, buf) {
+                    Ok(sample) => {
+                        debug!("received {:?}", sample);
+                        let leap = match sample.leap {
+                            0 => NtpLeapIndicator::NoWarning,
+                            1 => NtpLeapIndicator::Leap61,
+                            2 => NtpLeapIndicator::Leap59,
+                            _ => NtpLeapIndicator::Unknown,
+                        };
+
+                        let time = match self.clock.now() {
+                            Ok(time) => time,
+                            Err(e) => {
+                                error!(error = ?e, "There was an error retrieving the current time");
+                                std::process::exit(exitcode::NOPERM);
+                            }
+                        };
+
+                        let measurement = Measurement {
+                            delay: (),
+                            offset: NtpDuration::from_seconds(sample.offset),
+                            localtime: time,
+                            monotime: NtpInstant::now(),
+
+                            stratum: 0,
+                            root_delay: NtpDuration::ZERO,
+                            root_dispersion: NtpDuration::ZERO,
+                            leap,
+                            precision: 0, // TODO: compute on startup?
+                        };
+
+                        let controller_message = self.controller.handle_measurement(measurement);
+
+                        let update = SockSourceUpdate {
+                            snapshot: SockSourceSnapshot {
+                                source_id: ReferenceId::SOCK,
+                                stratum: 0,
+                            },
+                            message: controller_message,
+                        };
+                        self.channels
+                            .msg_for_system_sender
+                            .send(MsgForSystem::SockSourceUpdate(self.index, update))
+                            .await
+                            .ok();
+                    }
+                    Err(e) => {
+                        error!("Error deserializing sample: {}", e);
+                        continue;
+                    }
+                },
+                SelectResult::SystemUpdate(result) => match result {
+                    Ok(update) => {
+                        self.controller.handle_message(update.message);
+                    }
+                    Err(e) => {
+                        error!("Error receiving system update: {:?}", e)
+                    }
+                },
+            };
         }
     }
 

--- a/ntpd/src/daemon/sock_source.rs
+++ b/ntpd/src/daemon/sock_source.rs
@@ -1,0 +1,67 @@
+use std::{marker::PhantomData, pin::Pin, time::Duration};
+
+use ntp_proto::NtpClock;
+#[cfg(target_os = "linux")]
+use timestamped_socket::interface::InterfaceName;
+use tracing::{info, instrument, Instrument, Span};
+
+use tokio::time::{Instant, Sleep};
+
+use super::{ntp_source::Wait, spawn::SourceId};
+
+pub(crate) struct SockSourceTask<C: 'static + NtpClock + Send, T: Wait> {
+    _wait: PhantomData<T>,
+    index: SourceId,
+    clock: C,
+    interface: Option<InterfaceName>,
+    name: String,
+}
+
+impl<C, T> SockSourceTask<C, T>
+where
+    C: 'static + NtpClock + Send + Sync,
+    T: Wait,
+{
+    async fn run(&mut self, mut poll_wait: Pin<&mut T>) {
+        loop {
+            // temporary: prints "sock!" every second
+            info!("sock!");
+            poll_wait
+                .as_mut()
+                .reset(Instant::now() + Duration::from_secs(1));
+            poll_wait.as_mut().await;
+        }
+    }
+}
+
+impl<C> SockSourceTask<C, Sleep>
+where
+    C: 'static + NtpClock + Send + Sync,
+{
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(level = tracing::Level::ERROR, name = "Ntp Source", skip(clock))]
+    pub fn spawn(
+        index: SourceId,
+        name: String,
+        interface: Option<InterfaceName>,
+        clock: C,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(
+            (async move {
+                let poll_wait = tokio::time::sleep(std::time::Duration::default());
+                tokio::pin!(poll_wait);
+
+                let mut process = SockSourceTask {
+                    _wait: PhantomData,
+                    index,
+                    name,
+                    clock,
+                    interface,
+                };
+
+                process.run(poll_wait).await;
+            })
+            .instrument(Span::current()),
+        )
+    }
+}

--- a/ntpd/src/daemon/sock_source.rs
+++ b/ntpd/src/daemon/sock_source.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, path::Path};
 
 use ntp_proto::{
     Measurement, NtpClock, NtpDuration, NtpInstant, NtpLeapIndicator, OneWaySource,
-    OneWaySourceUpdate, ReferenceId, OneWaySourceSnapshot, SourceController, SystemSourceUpdate,
+    OneWaySourceSnapshot, OneWaySourceUpdate, ReferenceId, SourceController, SystemSourceUpdate,
 };
 use tracing::debug;
 use tracing::{error, instrument, Instrument, Span};

--- a/ntpd/src/daemon/spawn/mod.rs
+++ b/ntpd/src/daemon/spawn/mod.rs
@@ -136,6 +136,22 @@ pub enum SourceCreateParameters {
     Sock(SockSourceCreateParameters),
 }
 
+impl SourceCreateParameters {
+    pub fn get_id(&self) -> SourceId {
+        match self {
+            Self::Ntp(params) => params.id,
+            Self::Sock(params) => params.id,
+        }
+    }
+
+    pub fn get_addr(&self) -> String {
+        match self {
+            Self::Ntp(params) => params.addr.to_string(),
+            Self::Sock(params) => params.path.clone(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct NtpSourceCreateParameters {
     pub id: SourceId,

--- a/ntpd/src/daemon/spawn/mod.rs
+++ b/ntpd/src/daemon/spawn/mod.rs
@@ -6,6 +6,7 @@ use tokio::{
     sync::mpsc,
     time::{timeout, Instant},
 };
+use tracing::info;
 
 use super::{config::NormalizedAddress, system::NETWORK_WAIT_PERIOD};
 
@@ -81,6 +82,7 @@ impl SpawnEvent {
 pub enum SystemEvent {
     SourceRemoved(SourceRemovedEvent),
     SourceRegistered(NtpSourceCreateParameters),
+    SockSourceRegistered(SockSourceCreateParameters),
     Idle,
 }
 
@@ -234,6 +236,10 @@ pub async fn spawner_task<S: Spawner + Send + 'static>(
         match event {
             SystemEvent::SourceRegistered(source_params) => {
                 spawner.handle_registered(source_params).await?;
+            }
+            SystemEvent::SockSourceRegistered(_source_params) => {
+                // spawner.handle_registered(source_params).await?;
+                info!("TODO: handle sock source registered");
             }
             SystemEvent::SourceRemoved(removed_source) => {
                 spawner.handle_source_removed(removed_source).await?;

--- a/ntpd/src/daemon/spawn/mod.rs
+++ b/ntpd/src/daemon/spawn/mod.rs
@@ -254,7 +254,7 @@ pub async fn spawner_task<S: Spawner + Send + 'static>(
 mod tests {
     use super::{NtpSourceCreateParameters, SourceCreateParameters, SpawnAction, SpawnEvent};
 
-    pub fn get_npt_create_params(res: SpawnEvent) -> Option<NtpSourceCreateParameters> {
+    pub fn get_ntp_create_params(res: SpawnEvent) -> Option<NtpSourceCreateParameters> {
         let SpawnAction::Create(SourceCreateParameters::Ntp(params)) = res.action else {
             return None;
         };

--- a/ntpd/src/daemon/spawn/mod.rs
+++ b/ntpd/src/daemon/spawn/mod.rs
@@ -165,6 +165,7 @@ pub struct NtpSourceCreateParameters {
 pub struct SockSourceCreateParameters {
     pub id: SourceId,
     pub path: String,
+    pub noise_estimate: f64,
 }
 
 #[async_trait::async_trait]

--- a/ntpd/src/daemon/spawn/nts.rs
+++ b/ntpd/src/daemon/spawn/nts.rs
@@ -86,7 +86,7 @@ impl Spawner for NtsSpawner {
                     action_tx
                         .send(SpawnEvent::new(
                             self.id,
-                            SpawnAction::create(
+                            SpawnAction::create_ntp(
                                 SourceId::new(),
                                 address,
                                 self.config.address.deref().clone(),

--- a/ntpd/src/daemon/spawn/nts_pool.rs
+++ b/ntpd/src/daemon/spawn/nts_pool.rs
@@ -94,7 +94,7 @@ impl Spawner for NtsPoolSpawner {
                         action_tx
                             .send(SpawnEvent::new(
                                 self.id,
-                                SpawnAction::create(
+                                SpawnAction::create_ntp(
                                     id,
                                     address,
                                     self.config.addr.deref().clone(),

--- a/ntpd/src/daemon/spawn/pool.rs
+++ b/ntpd/src/daemon/spawn/pool.rs
@@ -81,7 +81,7 @@ impl Spawner for PoolSpawner {
             if let Some(addr) = self.known_ips.pop() {
                 let id = SourceId::new();
                 self.current_sources.push(PoolSource { id, addr });
-                let action = SpawnAction::create(
+                let action = SpawnAction::create_ntp(
                     id,
                     addr,
                     self.config.addr.deref().clone(),

--- a/ntpd/src/daemon/spawn/pool.rs
+++ b/ntpd/src/daemon/spawn/pool.rs
@@ -144,8 +144,8 @@ mod tests {
     use crate::daemon::{
         config::{NormalizedAddress, PoolSourceConfig},
         spawn::{
-            pool::PoolSpawner, tests::get_create_params, SourceRemovalReason, SourceRemovedEvent,
-            Spawner,
+            pool::PoolSpawner, tests::get_npt_create_params, SourceRemovalReason,
+            SourceRemovedEvent, Spawner,
         },
         system::MESSAGE_BUFFER_SIZE,
     };
@@ -170,7 +170,7 @@ mod tests {
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         let addr1 = params.addr;
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(
@@ -180,7 +180,7 @@ mod tests {
 
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         let addr2 = params.addr;
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(
@@ -302,12 +302,12 @@ mod tests {
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         let addr1 = params.addr;
 
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         let addr2 = params.addr;
 
         assert_ne!(addr1, addr2);
@@ -339,10 +339,10 @@ mod tests {
         assert!(!pool.is_complete());
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         let addr1 = params.addr;
         let res = action_rx.try_recv().unwrap();
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         let addr2 = params.addr;
         assert!(pool.is_complete());
 
@@ -356,7 +356,7 @@ mod tests {
         assert!(!pool.is_complete());
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         let addr3 = params.addr;
 
         // no duplicates!

--- a/ntpd/src/daemon/spawn/pool.rs
+++ b/ntpd/src/daemon/spawn/pool.rs
@@ -218,14 +218,14 @@ mod tests {
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_create_params(res);
+        let params = get_ntp_create_params(res).unwrap();
         let addr1 = params.addr;
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(params.protocol_version, ProtocolVersion::V5);
 
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_create_params(res);
+        let params = get_ntp_create_params(res).unwrap();
         let addr2 = params.addr;
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(params.protocol_version, ProtocolVersion::V5);
@@ -260,14 +260,14 @@ mod tests {
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_create_params(res);
+        let params = get_ntp_create_params(res).unwrap();
         let addr1 = params.addr;
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(params.protocol_version, ProtocolVersion::V4);
 
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_create_params(res);
+        let params = get_ntp_create_params(res).unwrap();
         let addr2 = params.addr;
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(params.protocol_version, ProtocolVersion::V4);

--- a/ntpd/src/daemon/spawn/pool.rs
+++ b/ntpd/src/daemon/spawn/pool.rs
@@ -144,7 +144,7 @@ mod tests {
     use crate::daemon::{
         config::{NormalizedAddress, PoolSourceConfig},
         spawn::{
-            pool::PoolSpawner, tests::get_npt_create_params, SourceRemovalReason,
+            pool::PoolSpawner, tests::get_ntp_create_params, SourceRemovalReason,
             SourceRemovedEvent, Spawner,
         },
         system::MESSAGE_BUFFER_SIZE,
@@ -170,7 +170,7 @@ mod tests {
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         let addr1 = params.addr;
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(
@@ -180,7 +180,7 @@ mod tests {
 
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         let addr2 = params.addr;
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(
@@ -302,12 +302,12 @@ mod tests {
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         let addr1 = params.addr;
 
         let res = action_rx.try_recv().unwrap();
         assert_eq!(spawner_id, res.id);
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         let addr2 = params.addr;
 
         assert_ne!(addr1, addr2);
@@ -339,10 +339,10 @@ mod tests {
         assert!(!pool.is_complete());
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         let addr1 = params.addr;
         let res = action_rx.try_recv().unwrap();
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         let addr2 = params.addr;
         assert!(pool.is_complete());
 
@@ -356,7 +356,7 @@ mod tests {
         assert!(!pool.is_complete());
         pool.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         let addr3 = params.addr;
 
         // no duplicates!

--- a/ntpd/src/daemon/spawn/sock.rs
+++ b/ntpd/src/daemon/spawn/sock.rs
@@ -1,0 +1,72 @@
+use tokio::sync::mpsc;
+
+use crate::daemon::config::SockSourceConfig;
+
+use super::{
+    standard::StandardSpawnError, SockSourceCreateParameters, SourceId, SourceRemovalReason,
+    SourceRemovedEvent, SpawnAction, SpawnEvent, Spawner, SpawnerId,
+};
+
+pub struct SockSpawner {
+    config: SockSourceConfig,
+    id: SpawnerId,
+    has_spawned: bool,
+}
+
+impl SockSpawner {
+    pub fn new(config: SockSourceConfig) -> SockSpawner {
+        SockSpawner {
+            config,
+            id: Default::default(),
+            has_spawned: false,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Spawner for SockSpawner {
+    type Error = StandardSpawnError;
+
+    async fn try_spawn(
+        &mut self,
+        action_tx: &mpsc::Sender<SpawnEvent>,
+    ) -> Result<(), StandardSpawnError> {
+        action_tx
+            .send(SpawnEvent::new(
+                self.id,
+                SpawnAction::CreateSock(SockSourceCreateParameters {
+                    id: SourceId::new(),
+                    path: self.config.path.clone(),
+                }),
+            ))
+            .await?;
+        self.has_spawned = true;
+        Ok(())
+    }
+
+    fn is_complete(&self) -> bool {
+        self.has_spawned
+    }
+
+    async fn handle_source_removed(
+        &mut self,
+        removed_source: SourceRemovedEvent,
+    ) -> Result<(), StandardSpawnError> {
+        if removed_source.reason != SourceRemovalReason::Demobilized {
+            self.has_spawned = false;
+        }
+        Ok(())
+    }
+
+    fn get_id(&self) -> SpawnerId {
+        self.id
+    }
+
+    fn get_addr_description(&self) -> String {
+        format!("{}", self.config.path)
+    }
+
+    fn get_description(&self) -> &str {
+        "sock"
+    }
+}

--- a/ntpd/src/daemon/spawn/sock.rs
+++ b/ntpd/src/daemon/spawn/sock.rs
@@ -37,6 +37,7 @@ impl Spawner for SockSpawner {
                 SpawnAction::Create(SourceCreateParameters::Sock(SockSourceCreateParameters {
                     id: SourceId::new(),
                     path: self.config.path.clone(),
+                    noise_estimate: self.config.measurement_noise_estimate.to_seconds(),
                 })),
             ))
             .await?;

--- a/ntpd/src/daemon/spawn/sock.rs
+++ b/ntpd/src/daemon/spawn/sock.rs
@@ -63,7 +63,7 @@ impl Spawner for SockSpawner {
     }
 
     fn get_addr_description(&self) -> String {
-        format!("{}", self.config.path)
+        self.config.path.to_string()
     }
 
     fn get_description(&self) -> &str {

--- a/ntpd/src/daemon/spawn/sock.rs
+++ b/ntpd/src/daemon/spawn/sock.rs
@@ -99,8 +99,11 @@ mod tests {
         let res = action_rx.try_recv().unwrap();
         assert_eq!(res.id, spawner_id);
 
-        let SpawnAction::Create(SourceCreateParameters::Sock(params)) = res.action else {
-            panic!("did not receive a sock create event!");
+        let SpawnAction::Create(create_params) = res.action;
+        assert_eq!(create_params.get_addr(), socket_path);
+
+        let SourceCreateParameters::Sock(params) = create_params else {
+            panic!("did not receive sock source create parameters!");
         };
         assert_eq!(params.path, socket_path);
         assert!((params.noise_estimate - noise_estimate).abs() < 1e-9);

--- a/ntpd/src/daemon/spawn/sock.rs
+++ b/ntpd/src/daemon/spawn/sock.rs
@@ -3,8 +3,8 @@ use tokio::sync::mpsc;
 use crate::daemon::config::SockSourceConfig;
 
 use super::{
-    standard::StandardSpawnError, SockSourceCreateParameters, SourceId, SourceRemovalReason,
-    SourceRemovedEvent, SpawnAction, SpawnEvent, Spawner, SpawnerId,
+    standard::StandardSpawnError, SockSourceCreateParameters, SourceCreateParameters, SourceId,
+    SourceRemovalReason, SourceRemovedEvent, SpawnAction, SpawnEvent, Spawner, SpawnerId,
 };
 
 pub struct SockSpawner {
@@ -34,10 +34,10 @@ impl Spawner for SockSpawner {
         action_tx
             .send(SpawnEvent::new(
                 self.id,
-                SpawnAction::CreateSock(SockSourceCreateParameters {
+                SpawnAction::Create(SourceCreateParameters::Sock(SockSourceCreateParameters {
                     id: SourceId::new(),
                     path: self.config.path.clone(),
-                }),
+                })),
             ))
             .await?;
         self.has_spawned = true;

--- a/ntpd/src/daemon/spawn/standard.rs
+++ b/ntpd/src/daemon/spawn/standard.rs
@@ -89,7 +89,7 @@ impl Spawner for StandardSpawner {
         action_tx
             .send(SpawnEvent::new(
                 self.id,
-                SpawnAction::create(
+                SpawnAction::create_ntp(
                     SourceId::new(),
                     addr,
                     self.config.address.deref().clone(),

--- a/ntpd/src/daemon/spawn/standard.rs
+++ b/ntpd/src/daemon/spawn/standard.rs
@@ -151,7 +151,7 @@ mod tests {
         config::{NormalizedAddress, StandardSource},
         spawn::{
             standard::StandardSpawner, tests::get_ntp_create_params, SourceRemovalReason,
-            SourceRemovedEvent, Spawner,
+            SourceRemovedEvent, SpawnAction, Spawner,
         },
         system::MESSAGE_BUFFER_SIZE,
     };
@@ -175,6 +175,8 @@ mod tests {
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(res.id, spawner_id);
+        let SpawnAction::Create(create_params) = &res.action;
+        assert_eq!(create_params.get_addr(), "127.0.0.1:123");
         let params = get_ntp_create_params(res).unwrap();
         assert_eq!(params.addr.to_string(), "127.0.0.1:123");
         #[cfg(feature = "unstable_ntpv5")]

--- a/ntpd/src/daemon/spawn/standard.rs
+++ b/ntpd/src/daemon/spawn/standard.rs
@@ -150,7 +150,7 @@ mod tests {
     use crate::daemon::{
         config::{NormalizedAddress, StandardSource},
         spawn::{
-            standard::StandardSpawner, tests::get_npt_create_params, SourceRemovalReason,
+            standard::StandardSpawner, tests::get_ntp_create_params, SourceRemovalReason,
             SourceRemovedEvent, Spawner,
         },
         system::MESSAGE_BUFFER_SIZE,
@@ -175,7 +175,7 @@ mod tests {
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(res.id, spawner_id);
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         assert_eq!(params.addr.to_string(), "127.0.0.1:123");
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(
@@ -258,7 +258,7 @@ mod tests {
         assert!(!spawner.is_complete());
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         assert!(spawner.is_complete());
 
         spawner
@@ -272,7 +272,7 @@ mod tests {
         assert!(!spawner.is_complete());
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         assert_eq!(params.addr.to_string(), "127.0.0.1:123");
         assert!(spawner.is_complete());
     }
@@ -297,7 +297,7 @@ mod tests {
         assert!(!spawner.is_complete());
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.recv().await.unwrap();
-        let params = get_npt_create_params(res).unwrap();
+        let params = get_ntp_create_params(res).unwrap();
         let initial_addr = params.addr;
         assert!(spawner.is_complete());
 
@@ -316,7 +316,7 @@ mod tests {
             assert!(!spawner.is_complete());
             spawner.try_spawn(&action_tx).await.unwrap();
             let res = action_rx.recv().await.unwrap();
-            let params = get_npt_create_params(res).unwrap();
+            let params = get_ntp_create_params(res).unwrap();
             seen_addresses.push(params.addr);
             assert!(spawner.is_complete());
         }

--- a/ntpd/src/daemon/spawn/standard.rs
+++ b/ntpd/src/daemon/spawn/standard.rs
@@ -208,7 +208,7 @@ mod tests {
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(res.id, spawner_id);
-        let params = get_create_params(res);
+        let params = get_ntp_create_params(res).unwrap();
         assert_eq!(params.addr.to_string(), "127.0.0.1:123");
         assert_eq!(params.protocol_version, ProtocolVersion::V5);
 
@@ -235,7 +235,7 @@ mod tests {
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(res.id, spawner_id);
-        let params = get_create_params(res);
+        let params = get_ntp_create_params(res).unwrap();
         assert_eq!(params.addr.to_string(), "127.0.0.1:123");
         assert_eq!(params.protocol_version, ProtocolVersion::V4);
 

--- a/ntpd/src/daemon/spawn/standard.rs
+++ b/ntpd/src/daemon/spawn/standard.rs
@@ -150,7 +150,7 @@ mod tests {
     use crate::daemon::{
         config::{NormalizedAddress, StandardSource},
         spawn::{
-            standard::StandardSpawner, tests::get_create_params, SourceRemovalReason,
+            standard::StandardSpawner, tests::get_npt_create_params, SourceRemovalReason,
             SourceRemovedEvent, Spawner,
         },
         system::MESSAGE_BUFFER_SIZE,
@@ -175,7 +175,7 @@ mod tests {
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
         assert_eq!(res.id, spawner_id);
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         assert_eq!(params.addr.to_string(), "127.0.0.1:123");
         #[cfg(feature = "unstable_ntpv5")]
         assert_eq!(
@@ -258,7 +258,7 @@ mod tests {
         assert!(!spawner.is_complete());
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         assert!(spawner.is_complete());
 
         spawner
@@ -272,7 +272,7 @@ mod tests {
         assert!(!spawner.is_complete());
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.try_recv().unwrap();
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         assert_eq!(params.addr.to_string(), "127.0.0.1:123");
         assert!(spawner.is_complete());
     }
@@ -297,7 +297,7 @@ mod tests {
         assert!(!spawner.is_complete());
         spawner.try_spawn(&action_tx).await.unwrap();
         let res = action_rx.recv().await.unwrap();
-        let params = get_create_params(res);
+        let params = get_npt_create_params(res).unwrap();
         let initial_addr = params.addr;
         assert!(spawner.is_complete());
 
@@ -316,7 +316,7 @@ mod tests {
             assert!(!spawner.is_complete());
             spawner.try_spawn(&action_tx).await.unwrap();
             let res = action_rx.recv().await.unwrap();
-            let params = get_create_params(res);
+            let params = get_npt_create_params(res).unwrap();
             seen_addresses.push(params.addr);
             assert!(spawner.is_complete());
         }

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -472,13 +472,12 @@ impl<
             },
         );
 
-        let (source, initial_actions) = if let Some(nts) = params.nts.take() {
-            self.system
-                .create_nts_source(source_id, params.addr, params.protocol_version, nts)?
-        } else {
-            self.system
-                .create_ntp_source(source_id, params.addr, params.protocol_version)?
-        };
+        let (source, initial_actions) = self.system.create_ntp_source(
+            source_id,
+            params.addr,
+            params.protocol_version,
+            params.nts.take(),
+        )?;
 
         SourceTask::spawn(
             source_id,

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -26,8 +26,9 @@ use std::{
 };
 
 use ntp_proto::{
-    KeySet, NtpClock, ObservableSourceState, SourceDefaultsConfig, SynchronizationConfig, System,
-    SystemActionIterator, SystemSnapshot, SystemSourceUpdate, TimeSyncController,
+    KeySet, MeasurementNoiseEstimator, NtpClock, ObservableSourceState, SourceDefaultsConfig,
+    SynchronizationConfig, System, SystemActionIterator, SystemSnapshot, SystemSourceUpdate,
+    TimeSyncController,
 };
 use timestamped_socket::interface::InterfaceName;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -510,10 +511,12 @@ impl<
             }
             SourceCreateParameters::Sock(ref params) => {
                 SockSourceTask::spawn(
-                    source_id,
                     params.path.clone(),
-                    self.interface,
                     self.clock.clone(),
+                    self.system.create_source_controller(
+                        source_id,
+                        MeasurementNoiseEstimator::Constant(params.noise_estimate),
+                    )?,
                 );
             }
         };

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -388,8 +388,8 @@ impl<
                     Ok(timer) => self.handle_state_update(timer, wait),
                 }
             }
-            MsgForSystem::SockSourceUpdate(index, update) => {
-                match self.system.handle_sock_source_update(index, update) {
+            MsgForSystem::OneWaySourceUpdate(index, update) => {
+                match self.system.handle_one_way_source_update(index, update) {
                     Err(e) => unreachable!("Could not process source measurement: {}", e),
                     Ok(timer) => self.handle_state_update(timer, wait),
                 }

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -515,6 +515,9 @@ impl<
                 );
             }
             SourceCreateParameters::Sock(ref params) => {
+                let source = self
+                    .system
+                    .create_sock_source(source_id, params.noise_estimate)?;
                 SockSourceTask::spawn(
                     source_id,
                     params.path.clone(),
@@ -524,8 +527,7 @@ impl<
                         system_update_receiver: self.system_update_sender.subscribe(),
                         source_snapshots: self.source_snapshots.clone(),
                     },
-                    self.system
-                        .create_sock_source_controller(source_id, params.noise_estimate)?,
+                    source,
                 );
             }
         };

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -26,9 +26,8 @@ use std::{
 };
 
 use ntp_proto::{
-    KeySet, MeasurementNoiseEstimator, NtpClock, ObservableSourceState, SourceDefaultsConfig,
-    SynchronizationConfig, System, SystemActionIterator, SystemSnapshot, SystemSourceUpdate,
-    TimeSyncController,
+    KeySet, NtpClock, ObservableSourceState, SourceDefaultsConfig, SynchronizationConfig, System,
+    SystemActionIterator, SystemSnapshot, SystemSourceUpdate, TimeSyncController,
 };
 use timestamped_socket::interface::InterfaceName;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -525,10 +524,8 @@ impl<
                         system_update_receiver: self.system_update_sender.subscribe(),
                         source_snapshots: self.source_snapshots.clone(),
                     },
-                    self.system.create_source_controller(
-                        source_id,
-                        MeasurementNoiseEstimator::Constant(params.noise_estimate),
-                    )?,
+                    self.system
+                        .create_sock_source_controller(source_id, params.noise_estimate)?,
                 );
             }
         };

--- a/ntpd/src/force_sync/algorithm.rs
+++ b/ntpd/src/force_sync/algorithm.rs
@@ -127,7 +127,7 @@ impl<C: NtpClock> TimeSyncController for SingleShotController<C> {
     type ControllerMessage = SingleShotControllerMessage;
     type SourceMessage = Measurements;
     type NtpSourceController = SingleShotSourceController<NtpDuration>;
-    type SockSourceController = SingleShotSourceController<()>;
+    type OneWaySourceController = SingleShotSourceController<()>;
 
     fn new(
         clock: Self::Clock,
@@ -158,11 +158,11 @@ impl<C: NtpClock> TimeSyncController for SingleShotController<C> {
         }
     }
 
-    fn add_sock_source(
+    fn add_one_way_source(
         &mut self,
         _id: Self::SourceId,
         _measurement_noise_estimate: f64,
-    ) -> Self::SockSourceController {
+    ) -> Self::OneWaySourceController {
         SingleShotSourceController::<()> {
             delay_type: PhantomData,
             min_poll_interval: self.min_poll_interval,

--- a/ntpd/src/force_sync/algorithm.rs
+++ b/ntpd/src/force_sync/algorithm.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use ntp_proto::{
-    Measurement, NtpClock, NtpDuration, PollInterval, SourceController, TimeSyncController,
+    Measurement, MeasurementNoiseEstimator, NtpClock, NtpDuration, PollInterval, SourceController,
+    TimeSyncController,
 };
 use serde::Deserialize;
 
@@ -116,7 +117,11 @@ impl<C: NtpClock> TimeSyncController for SingleShotController<C> {
         Ok(())
     }
 
-    fn add_source(&mut self, _id: Self::SourceId) -> Self::SourceController {
+    fn add_source(
+        &mut self,
+        _id: Self::SourceId,
+        _noise_estimator: MeasurementNoiseEstimator,
+    ) -> Self::SourceController {
         SingleShotSourceController {
             min_poll_interval: self.min_poll_interval,
             done: false,

--- a/ntpd/src/force_sync/algorithm.rs
+++ b/ntpd/src/force_sync/algorithm.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use crate::daemon::spawn::SourceId;
 
 #[derive(Debug, Clone)]
-pub(crate) enum Measurements {
+pub enum Measurements {
     Ntp(Measurement<NtpDuration>),
     Sock(Measurement<()>),
 }

--- a/ntpd/src/force_sync/algorithm.rs
+++ b/ntpd/src/force_sync/algorithm.rs
@@ -1,16 +1,47 @@
-use std::collections::HashMap;
+use std::fmt::Debug;
+use std::{collections::HashMap, marker::PhantomData};
 
 use ntp_proto::{
-    Measurement, MeasurementNoiseEstimator, NtpClock, NtpDuration, PollInterval, SourceController,
-    TimeSyncController,
+    Measurement, NtpClock, NtpDuration, PollInterval, SourceController, TimeSyncController,
 };
 use serde::Deserialize;
 
 use crate::daemon::spawn::SourceId;
 
+#[derive(Debug, Clone)]
+pub(crate) enum Measurements {
+    Ntp(Measurement<NtpDuration>),
+    Sock(Measurement<()>),
+}
+
+impl Measurements {
+    fn get_offset(&self) -> NtpDuration {
+        match self {
+            Measurements::Ntp(measurement) => measurement.offset,
+            Measurements::Sock(measurement) => measurement.offset,
+        }
+    }
+}
+
+pub trait WrapMeasurements<D: Debug + Copy + Clone> {
+    fn wrap(&self) -> Measurements;
+}
+
+impl WrapMeasurements<NtpDuration> for Measurement<NtpDuration> {
+    fn wrap(&self) -> Measurements {
+        Measurements::Ntp(*self)
+    }
+}
+
+impl WrapMeasurements<()> for Measurement<()> {
+    fn wrap(&self) -> Measurements {
+        Measurements::Sock(*self)
+    }
+}
+
 pub(crate) struct SingleShotController<C> {
     pub(super) clock: C,
-    sources: HashMap<SourceId, Measurement>,
+    sources: HashMap<SourceId, Measurements>,
     min_poll_interval: PollInterval,
     min_agreeing: usize,
 }
@@ -20,7 +51,8 @@ pub(crate) struct SingleShotControllerConfig {
     pub expected_sources: usize,
 }
 
-pub(crate) struct SingleShotSourceController {
+pub(crate) struct SingleShotSourceController<D: Debug + Copy + Clone> {
+    delay_type: PhantomData<D>,
     min_poll_interval: PollInterval,
     done: bool,
 }
@@ -46,11 +78,11 @@ impl<C: NtpClock> SingleShotController<C> {
             .flat_map(|m| {
                 [
                     Event {
-                        offset: m.offset - Self::ASSUMED_UNCERTAINTY,
+                        offset: m.get_offset() - Self::ASSUMED_UNCERTAINTY,
                         count: 1,
                     },
                     Event {
-                        offset: m.offset + Self::ASSUMED_UNCERTAINTY,
+                        offset: m.get_offset() + Self::ASSUMED_UNCERTAINTY,
                         count: -1,
                     },
                 ]
@@ -74,9 +106,9 @@ impl<C: NtpClock> SingleShotController<C> {
             let mut sum = 0.0;
             let mut count = 0;
             for source in self.sources.values() {
-                if source.offset.abs_diff(peak_offset) <= Self::ASSUMED_UNCERTAINTY {
+                if source.get_offset().abs_diff(peak_offset) < Self::ASSUMED_UNCERTAINTY {
                     count += 1;
-                    sum += source.offset.to_seconds()
+                    sum += source.get_offset().to_seconds()
                 }
             }
 
@@ -93,8 +125,9 @@ impl<C: NtpClock> TimeSyncController for SingleShotController<C> {
     type SourceId = SourceId;
     type AlgorithmConfig = SingleShotControllerConfig;
     type ControllerMessage = SingleShotControllerMessage;
-    type SourceMessage = Measurement;
-    type SourceController = SingleShotSourceController;
+    type SourceMessage = Measurements;
+    type NtpSourceController = SingleShotSourceController<NtpDuration>;
+    type SockSourceController = SingleShotSourceController<()>;
 
     fn new(
         clock: Self::Clock,
@@ -117,12 +150,21 @@ impl<C: NtpClock> TimeSyncController for SingleShotController<C> {
         Ok(())
     }
 
-    fn add_source(
+    fn add_source(&mut self, _id: Self::SourceId) -> Self::NtpSourceController {
+        SingleShotSourceController::<NtpDuration> {
+            delay_type: PhantomData,
+            min_poll_interval: self.min_poll_interval,
+            done: false,
+        }
+    }
+
+    fn add_sock_source(
         &mut self,
         _id: Self::SourceId,
-        _noise_estimator: MeasurementNoiseEstimator,
-    ) -> Self::SourceController {
-        SingleShotSourceController {
+        _measurement_noise_estimate: f64,
+    ) -> Self::SockSourceController {
+        SingleShotSourceController::<()> {
+            delay_type: PhantomData,
             min_poll_interval: self.min_poll_interval,
             done: false,
         }
@@ -155,9 +197,13 @@ impl<C: NtpClock> TimeSyncController for SingleShotController<C> {
     }
 }
 
-impl SourceController for SingleShotSourceController {
+impl<D: Debug + Copy + Clone + Send + 'static> SourceController for SingleShotSourceController<D>
+where
+    Measurement<D>: WrapMeasurements<D>,
+{
     type ControllerMessage = SingleShotControllerMessage;
-    type SourceMessage = Measurement;
+    type MeasurementDelay = D;
+    type SourceMessage = Measurements;
 
     fn handle_message(&mut self, _message: Self::ControllerMessage) {
         //ignore
@@ -165,10 +211,10 @@ impl SourceController for SingleShotSourceController {
 
     fn handle_measurement(
         &mut self,
-        measurement: ntp_proto::Measurement,
+        measurement: Measurement<Self::MeasurementDelay>,
     ) -> Option<Self::SourceMessage> {
         self.done = true;
-        Some(measurement)
+        Some(measurement.wrap())
     }
 
     fn desired_poll_interval(&self) -> ntp_proto::PollInterval {

--- a/ntpd/src/force_sync/mod.rs
+++ b/ntpd/src/force_sync/mod.rs
@@ -126,9 +126,9 @@ pub(crate) async fn force_sync(config: Option<PathBuf>) -> std::io::Result<ExitC
     let mut total_sources = 0;
     for source in &config.sources {
         match source {
-            config::NtpSourceConfig::Standard(_) | config::NtpSourceConfig::Nts(_) => {
-                total_sources += 1
-            }
+            config::NtpSourceConfig::Standard(_)
+            | config::NtpSourceConfig::Nts(_)
+            | config::NtpSourceConfig::Sock(_) => total_sources += 1,
             config::NtpSourceConfig::Pool(PoolSourceConfig { count, .. }) => total_sources += count,
             #[cfg(feature = "unstable_nts-pool")]
             config::NtpSourceConfig::NtsPool(NtsPoolSourceConfig { count, .. }) => {


### PR DESCRIPTION
This PR builds on #1673 to add a sock time source for GPSD sockets.

The sock source can for example be configured as follows in the config file:
```toml
[[source]]
mode = "sock"
path = "/run/chrony.ttyAMA0.sock"
measurement_noise_estimate = 0.001
```
The NTP daemon will create the socket, which means that if you (re-)start GPSD, GPSD will send time data to us.