### PR TITLE
Reenabled key exchange connection limiter test for macos.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -42,7 +42,7 @@ jobs:
           - rust: "stable"
             os: macos-latest
             features: ""
-            target: "x86_64-apple-darwin"
+            target: "aarch64-apple-darwin"
           - rust: "stable"
             os: ubuntu-latest
             features: "--all-features"
@@ -58,7 +58,7 @@ jobs:
           - rust: "stable"
             os: macos-latest
             features: "--all-features"
-            target: "x86_64-apple-darwin"
+            target: "aarch64-apple-darwin"
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/ntpd/src/daemon/keyexchange.rs
+++ b/ntpd/src/daemon/keyexchange.rs
@@ -780,7 +780,6 @@ mod tests {
         assert_eq!(len, 16);
     }
 
-    #[cfg(not(target_os = "macos"))]
     #[tokio::test]
     async fn key_exchange_connection_limiter() {
         let provider = KeySetProvider::new(1);
@@ -820,7 +819,7 @@ mod tests {
         let ca = include_bytes!("../../test-keys/testca.pem");
 
         assert!(tokio::time::timeout(
-            std::time::Duration::from_millis(200),
+            std::time::Duration::from_millis(750),
             key_exchange_client(
                 "localhost".to_string(),
                 5435,
@@ -837,7 +836,7 @@ mod tests {
         drop(blocker);
 
         let result = tokio::time::timeout(
-            std::time::Duration::from_millis(200),
+            std::time::Duration::from_millis(750), // large timeout is needed to ensure test succeeds consistently on MacOS M2 E-cores
             key_exchange_client(
                 "localhost".to_string(),
                 5435,


### PR DESCRIPTION
Closes #1525

Fix of underlying cause was in #1739, together with a higher timeout to ensure the test also succeeds on efficiency cores.