### PR TITLE
Adds reference_id setting

### DIFF
--- a/docs/man/ntp.toml.5.md
+++ b/docs/man/ntp.toml.5.md
@@ -337,6 +337,10 @@ time sources is gathered and applied to the system clock.
     time source. Can be used in servers to indicate that there are external
     mechanisms synchronizing the clock.
 
+`reference-id` = *reference-id* (**XNON**)
+:   Sets the reported NTP clock reference id when local-statum is set to `1`.
+    This is used to indicate the source of the time reference (`GPS` etc.).
+
 ## `[synchronization.algorithm]`
 Warning: the algorithm section contains mostly internal algorithm tweaks that
 generally do not need to be changed. However, they are offered here for specific

--- a/docs/precompiled/man/ntp.toml.5
+++ b/docs/precompiled/man/ntp.toml.5
@@ -418,6 +418,12 @@ have been configured, or when the time has not yet been synchronized
 from an NTP time source.
 Can be used in servers to indicate that there are external mechanisms
 synchronizing the clock.
+.TP
+\f[V]reference-id\f[R] = \f[I]reference-id\f[R] (\f[B]XNON\f[R])
+Sets the reported NTP clock reference id when local-statum is set to
+\f[V]1\f[R].
+This is used to indicate the source of the time reference (\f[V]GPS\f[R]
+etc.).
 .SS \f[V][synchronization.algorithm]\f[R]
 .PP
 Warning: the algorithm section contains mostly internal algorithm tweaks

--- a/ntp-proto/src/config.rs
+++ b/ntp-proto/src/config.rs
@@ -22,6 +22,56 @@ where
 }
 
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ReferenceIdConfig {
+    id: u32,
+}
+
+impl ReferenceIdConfig {
+    pub(crate) fn to_reference_id(self) -> crate::ReferenceId {
+        crate::ReferenceId::from_int(self.id)
+    }
+}
+
+// Deserialize from the string type in config
+impl<'de> Deserialize<'de> for ReferenceIdConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ReferenceIdConfigVisitor;
+
+        impl Visitor<'_> for ReferenceIdConfigVisitor {
+            type Value = ReferenceIdConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Up to 4-character string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let mut chars: Vec<char> = v.chars().collect();
+                if chars.len() > 4 {
+                    return Err(E::invalid_length(chars.len(), &self));
+                }
+
+                // Pad with spaces
+                while chars.len() < 4 {
+                    chars.push(' ');
+                }
+
+                let encoded = chars.iter().fold(0u32, |acc, &c| (acc << 8) | (c as u32));
+
+                Ok(ReferenceIdConfig { id: encoded })
+            }
+        }
+
+        deserializer.deserialize_str(ReferenceIdConfigVisitor)
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone)]
 pub struct StepThreshold {
     pub forward: Option<NtpDuration>,
     pub backward: Option<NtpDuration>,
@@ -263,6 +313,46 @@ pub struct SynchronizationConfig {
     /// synchronizing the clock
     #[serde(default = "default_local_stratum")]
     pub local_stratum: u8,
+
+    /// Reference ID for clock synchronization. When stratum is 1 this value
+    /// is used - the value is left justified, limited to four characters
+    /// and zero padded.
+    ///
+    /// From RFC 5905:
+    ///
+    ///  +------+----------------------------------------------------------+
+    ///  | ID   | Clock Source                                             |
+    ///  +------+----------------------------------------------------------+
+    ///  | GOES | Geosynchronous Orbit Environment Satellite               |
+    ///  | GPS  | Global Position System                                   |
+    ///  | GAL  | Galileo Positioning System                               |
+    ///  | PPS  | Generic pulse-per-second                                 |
+    ///  | IRIG | Inter-Range Instrumentation Group                        |
+    ///  | WWVB | LF Radio WWVB Ft. Collins, CO 60 kHz                     |
+    ///  | DCF  | LF Radio DCF77 Mainflingen, DE 77.5 kHz                  |
+    ///  | HBG  | LF Radio HBG Prangins, HB 75 kHz                         |
+    ///  | MSF  | LF Radio MSF Anthorn, UK 60 kHz                          |
+    ///  | JJY  | LF Radio JJY Fukushima, JP 40 kHz, Saga, JP 60 kHz       |
+    ///  | LORC | MF Radio LORAN C station, 100 kHz                        |
+    ///  | TDF  | MF Radio Allouis, FR 162 kHz                             |
+    ///  | CHU  | HF Radio CHU Ottawa, Ontario                             |
+    ///  | WWV  | HF Radio WWV Ft. Collins, CO                             |
+    ///  | WWVH | HF Radio WWVH Kauai, HI                                  |
+    ///  | NIST | NIST telephone modem                                     |
+    ///  | ACTS | NIST telephone modem                                     |
+    ///  | USNO | USNO telephone modem                                     |
+    ///  | PTB  | European telephone modem                                 |
+    ///  +------+----------------------------------------------------------+
+    ///
+    /// Any string beginning with the ASCII character "X" is can be used for
+    /// experimentation and development.
+    ///
+    /// The default value is "XNON" (i.e. NONE)
+    ///
+    /// When the local-stratum not 1 the reference-id is ignored.
+    ///
+    #[serde(default = "default_reference_id")]
+    pub reference_id: ReferenceIdConfig,
 }
 
 impl Default for SynchronizationConfig {
@@ -275,12 +365,21 @@ impl Default for SynchronizationConfig {
             accumulated_step_panic_threshold: None,
 
             local_stratum: default_local_stratum(),
+            reference_id: default_reference_id(),
         }
     }
 }
 
 fn default_minimum_agreeing_sources() -> usize {
     3
+}
+
+fn default_reference_id() -> ReferenceIdConfig {
+    ReferenceIdConfig {
+        id: ['X', 'N', 'O', 'N']
+            .iter()
+            .fold(0u32, |acc, &c| (acc << 8) | (c as u32)),
+    }
 }
 
 fn default_single_step_panic_threshold() -> StepThreshold {

--- a/ntp-proto/src/config.rs
+++ b/ntp-proto/src/config.rs
@@ -44,7 +44,7 @@ impl<'de> Deserialize<'de> for ReferenceIdConfig {
             type Value = ReferenceIdConfig;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("Up to 4-character string")
+                formatter.write_str("up to 4-character string")
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>

--- a/ntp-proto/src/system.rs
+++ b/ntp-proto/src/system.rs
@@ -212,6 +212,8 @@ impl<SourceId: Hash + Eq + Copy + Debug, Controller: TimeSyncController<SourceId
         if synchronization_config.local_stratum == 1 {
             // We are a stratum 1 server so mark our selves synchronized.
             system.time_snapshot.leap_indicator = NtpLeapIndicator::NoWarning;
+            // Set the reference id for the system
+            system.reference_id = synchronization_config.reference_id.to_reference_id();
         }
 
         Ok(System {

--- a/ntpd/tests/ctl.rs
+++ b/ntpd/tests/ctl.rs
@@ -109,3 +109,49 @@ fn test_help() {
     assert!(contains_bytes(&result.stdout, b"usage"));
     assert_eq!(result.status.code(), Some(0));
 }
+
+#[test]
+fn test_bad_reference_id() {
+    // Reference ID is too long
+
+    let test_config_contents = r#"
+[[source]]
+mode = "pool"
+address = "ntpd-rs.pool.ntp.org"
+count = 4
+
+[synchronization]
+local-stratum = 1
+reference-id = "TOO_LONG"
+"#;
+
+    let test_config_path = format!("{CARGO_TARGET_TMPDIR}/reference_id_bad_test_config");
+    std::fs::write(&test_config_path, test_config_contents.as_bytes()).unwrap();
+
+    let result = test_ntp_ctl_output(&["validate", "-c", &test_config_path]);
+
+    assert!(contains_bytes(&result.stderr, b"up to 4-character string"));
+    assert_eq!(result.status.code(), Some(1));
+}
+
+#[test]
+fn test_good_reference_id() {
+    let test_config_contents = r#"
+[[source]]
+mode = "pool"
+address = "ntpd-rs.pool.ntp.org"
+count = 4
+
+[synchronization]
+local-stratum = 1
+reference-id = "GPS"
+"#;
+
+    let test_config_path = format!("{CARGO_TARGET_TMPDIR}/reference_id_good_test_config");
+    std::fs::write(&test_config_path, test_config_contents.as_bytes()).unwrap();
+
+    let result = test_ntp_ctl_output(&["validate", "-c", &test_config_path]);
+
+    assert!(contains_bytes(&result.stderr, b"good"));
+    assert_eq!(result.status.code(), Some(0));
+}


### PR DESCRIPTION
Enables end user to set the value for 'reference_id' if operating as a server in stratum 1, as discussed in https://github.com/pendulum-project/ntpd-rs/issues/1718