### PR TITLE
Add provides = time-daemon to deb metadata

### DIFF
--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -91,6 +91,8 @@ conf-files = [
   "/etc/ntpd-rs/ntp.toml",
 ]
 provides = "time-daemon"
+conflicts = "time-daemon"
+replaces = "time-daemon"
 
 [package.metadata.generate-rpm]
 name = "ntpd-rs"

--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -90,6 +90,7 @@ assets = [
 conf-files = [
   "/etc/ntpd-rs/ntp.toml",
 ]
+provides = "time-daemon"
 
 [package.metadata.generate-rpm]
 name = "ntpd-rs"


### PR DESCRIPTION
In Debian and Ubuntu, time-daemon is provided/conflict/replace by all of chrony, ntpsec, openntpd, systemd-timesyncd

This helps to ensure there's not multiple fighting NTP implementations, and allows other packages to depend on having NTP generically.

Having ntpd-rs provide it eases switching them out and keeping dependencies satisfied.
