### PR TITLE
Switch to precision field for specifying pps and sock noise.

### DIFF
--- a/docs/guide/gps-pps.md
+++ b/docs/guide/gps-pps.md
@@ -9,11 +9,11 @@ GPSd can be added as a time source for ntpd-rs by adding the following to the co
 [[source]]
 mode = "sock"
 path = "/run/chrony.ttyAMA0.sock"
-measurement_noise_estimate = 1e-6
+precision = 1e-3
 ```
 The `path` points to the location of the socket that GPSd writes timing data to. This socket was originally meant for chrony, but ntpd-rs also supports this same socket format. Here, `ttyAMA0` is the GPS receiver device used by GPSd.
 
-The `measurement_noise_estimate` gives a static estimate of how noisy GPSd's timing data is. Normally with NTP time sources, we would use the network delay as an independent estimate of how noisy the data is. When using GPSd as a time source, we do not have a good estimate of the noise, so we use a static noise estimate instead. The noise estimate should be a quarter of the expected variance.
+The `precision` gives a static estimate of how noisy GPSd's timing data is. Normally with NTP time sources, we would use the network delay as an independent estimate of how noisy the data is. When using GPSd as a time source, we do not have a good estimate of the noise, so we use a static noise estimate instead. The noise estimate should be one standard deviation.
 
 ### Setting up GPSd
 In order for GPSd to connect to ntpd-rs, GPSd must start after ntpd-rs. This is because ntpd-rs needs to create a socket which GPSd will only use if it exists when GPSd starts.
@@ -33,7 +33,7 @@ Here is an example configuration of a 1 PPS device in ntpd-rs:
 [[source]]
 mode = "pps"
 path = "/dev/pps0"
-measurement_noise_estimate = 1e-14
+precision = 1e-7
 ```
 
 By default, PPS sources are treated as 1 PPS sources, which send a pulse every rounded second. For e.g. a 10 PPS device, the source can be configured with a period of 0.1 seconds:
@@ -41,6 +41,6 @@ By default, PPS sources are treated as 1 PPS sources, which send a pulse every r
 [[source]]
 mode = "pps"
 path = "/dev/pps0"
-measurement_noise_estimate = 1e-14
+precision = 1e-7
 period = 0.1
 ```

--- a/docs/man/ntp.toml.5.md
+++ b/docs/man/ntp.toml.5.md
@@ -111,6 +111,15 @@ sources.
 :   `pool` mode only. Specifies a list of IP addresses of servers in the pool
     which should not be used. For example: `["127.0.0.1"]`. Empty by default.
 
+`measurement_noise_estimate` = *Noise variance (seconds squared)*
+:   `pps` and `sock` mode only. Deprecated, use `precision` instead.
+
+`precision` = *Noise standard deviation (seconds)*
+:   `pps` and `sock` mode only. Precision of the source. This should be an estimate
+    of the size of the expected measurement noise. Technically defined as the
+    1-standard deviation bound on the measurement error. This is needed as
+    `sock` and `pps` sources don't have a good way to estimate their own error.
+
 `poll-interval-limits` = { `min` = *min*, `max` = *max* } (defaults from `[source-defaults]`)
 :   Specifies the limit on how often a source is queried for a new time. For
     most instances the defaults will be adequate. The min and max are given as

--- a/docs/precompiled/man/ntp.toml.5
+++ b/docs/precompiled/man/ntp.toml.5
@@ -146,6 +146,20 @@ be used.
 For example: \f[V][\[dq]127.0.0.1\[dq]]\f[R].
 Empty by default.
 .TP
+\f[V]measurement_noise_estimate\f[R] = \f[I]Noise variance (seconds squared)\f[R]
+\f[V]pps\f[R] and \f[V]sock\f[R] mode only.
+Deprecated, use \f[V]precision\f[R] instead.
+.TP
+\f[V]precision\f[R] = \f[I]Noise standard deviation (seconds)\f[R]
+\f[V]pps\f[R] and \f[V]sock\f[R] mode only.
+Precision of the source.
+This should be an estimate of the size of the expected measurement
+noise.
+Technically defined as the 1-standard deviation bound on the measurement
+error.
+This is needed as \f[V]sock\f[R] and \f[V]pps\f[R] sources don\[cq]t
+have a good way to estimate their own error.
+.TP
 \f[V]poll-interval-limits\f[R] = { \f[V]min\f[R] = \f[I]min\f[R], \f[V]max\f[R] = \f[I]max\f[R] } (defaults from \f[V][source-defaults]\f[R])
 Specifies the limit on how often a source is queried for a new time.
 For most instances the defaults will be adequate.

--- a/ntpd/src/daemon/config/ntp_source.rs
+++ b/ntpd/src/daemon/config/ntp_source.rs
@@ -110,11 +110,90 @@ pub struct NtsPoolSourceConfig {
     pub ntp_version: Option<NtpVersion>,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct SockSourceConfig {
     pub path: PathBuf,
-    pub measurement_noise_estimate: f64,
+    pub precision: f64,
+}
+
+impl<'de> Deserialize<'de> for SockSourceConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "snake_case")]
+        enum Field {
+            Path,
+            Precision,
+            MeasurementNoiseEstimate,
+        }
+
+        struct SockSourceConfigVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for SockSourceConfigVisitor {
+            type Value = SockSourceConfig;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("struct SockSourceConfig")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<SockSourceConfig, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut path = None;
+                let mut precision = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Path => {
+                            if path.is_some() {
+                                return Err(de::Error::duplicate_field("path"));
+                            }
+                            path = Some(map.next_value()?);
+                        }
+                        Field::MeasurementNoiseEstimate => {
+                            tracing::warn!("The measurement_noise_estimate field is deprecated. Please switch to using the precision field");
+                            if precision.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "measurement_noise_estimate",
+                                ));
+                            }
+                            let variance: f64 = map.next_value()?;
+                            if variance.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater) {
+                                return Err(de::Error::invalid_value(
+                                    serde::de::Unexpected::Float(variance),
+                                    &"measurement_noise_estimate should be positive",
+                                ));
+                            }
+                            precision = Some(variance.sqrt());
+                        }
+                        Field::Precision => {
+                            if precision.is_some() {
+                                return Err(de::Error::duplicate_field("precision"));
+                            }
+                            let precision_raw: f64 = map.next_value()?;
+                            if precision_raw.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater)
+                            {
+                                return Err(de::Error::invalid_value(
+                                    serde::de::Unexpected::Float(precision_raw),
+                                    &"measurement_noise_estimate should be positive",
+                                ));
+                            }
+                            precision = Some(precision_raw);
+                        }
+                    }
+                }
+                let path = path.ok_or_else(|| serde::de::Error::missing_field("path"))?;
+                let precision =
+                    precision.ok_or_else(|| serde::de::Error::missing_field("precision"))?;
+                Ok(SockSourceConfig { path, precision })
+            }
+        }
+
+        const FIELDS: &[&str] = &["path", "precision", "measurement_noise_estimate"];
+        deserializer.deserialize_struct("SockSourceConfig", FIELDS, SockSourceConfigVisitor)
+    }
 }
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -164,17 +243,111 @@ pub struct FlattenedPair<T, U> {
     pub second: U,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct PpsSourceConfig {
     pub path: PathBuf,
-    pub measurement_noise_estimate: f64,
-    #[serde(default = "default_period")]
+    pub precision: f64,
     pub period: f64,
 }
 
-fn default_period() -> f64 {
-    1.
+impl<'de> Deserialize<'de> for PpsSourceConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "snake_case")]
+        enum Field {
+            Path,
+            Precision,
+            MeasurementNoiseEstimate,
+            Period,
+        }
+
+        struct PpsSourceConfigVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PpsSourceConfigVisitor {
+            type Value = PpsSourceConfig;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("struct PpsSourceConfig")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<PpsSourceConfig, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut path = None;
+                let mut precision = None;
+                let mut period = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Path => {
+                            if path.is_some() {
+                                return Err(de::Error::duplicate_field("path"));
+                            }
+                            path = Some(map.next_value()?);
+                        }
+                        Field::MeasurementNoiseEstimate => {
+                            tracing::warn!("The measurement_noise_estimate field is deprecated. Please switch to using the precision field");
+                            if precision.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "measurement_noise_estimate",
+                                ));
+                            }
+                            let variance: f64 = map.next_value()?;
+                            if variance.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater) {
+                                return Err(de::Error::invalid_value(
+                                    serde::de::Unexpected::Float(variance),
+                                    &"measurement_noise_estimate should be positive",
+                                ));
+                            }
+                            precision = Some(variance.sqrt());
+                        }
+                        Field::Precision => {
+                            if precision.is_some() {
+                                return Err(de::Error::duplicate_field("precision"));
+                            }
+                            let precision_raw: f64 = map.next_value()?;
+                            if precision_raw.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater)
+                            {
+                                return Err(de::Error::invalid_value(
+                                    serde::de::Unexpected::Float(precision_raw),
+                                    &"measurement_noise_estimate should be positive",
+                                ));
+                            }
+                            precision = Some(precision_raw);
+                        }
+                        Field::Period => {
+                            if period.is_some() {
+                                return Err(de::Error::duplicate_field("period"));
+                            }
+                            let period_raw: f64 = map.next_value()?;
+                            if period_raw.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater) {
+                                return Err(de::Error::invalid_value(
+                                    serde::de::Unexpected::Float(period_raw),
+                                    &"period should be positive",
+                                ));
+                            }
+                            period = Some(period_raw);
+                        }
+                    }
+                }
+                let path = path.ok_or_else(|| serde::de::Error::missing_field("path"))?;
+                let precision =
+                    precision.ok_or_else(|| serde::de::Error::missing_field("precision"))?;
+                let period = period.unwrap_or(1.0);
+                Ok(PpsSourceConfig {
+                    path,
+                    precision,
+                    period,
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &["path", "precision", "measurement_noise_estimate"];
+        deserializer.deserialize_struct("PpsSourceConfig", FIELDS, PpsSourceConfigVisitor)
+    }
 }
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
@@ -604,6 +777,274 @@ mod tests {
             "#,
         );
         assert!(test2.is_err());
+    }
+
+    #[test]
+    fn test_sock_config_parsing() {
+        #[derive(Deserialize, Debug)]
+        struct TestConfig {
+            #[allow(unused)]
+            source: NtpSourceConfig,
+        }
+
+        let TestConfig {
+            source: NtpSourceConfig::Sock(test),
+        } = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+                measurement_noise_estimate = 0.0625
+            "#,
+        )
+        .unwrap()
+        else {
+            panic!("Unexpected source type");
+        };
+        assert_eq!(test.precision, 0.25);
+
+        let TestConfig {
+            source: NtpSourceConfig::Sock(test),
+        } = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+                precision = 0.25
+            "#,
+        )
+        .unwrap()
+        else {
+            panic!("Unexpected source type");
+        };
+        assert_eq!(test.precision, 0.25);
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+                precision = 0.25
+                measurement_noise_estimate = 0.0625
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                precision = 0.25
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+                precision = 0.25
+                unknown_field = 5
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+                precision = -0.25
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+                measurement_noise_estimate = -0.0625
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+                precision = 0.0
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+                [source]
+                mode = "sock"
+                path = "/test/path"
+                measurement_noise_estimate = 0.0
+            "#,
+        );
+        assert!(test.is_err());
+    }
+
+    #[test]
+    fn test_pps_config_parsing() {
+        #[derive(Deserialize, Debug)]
+        struct TestConfig {
+            #[allow(unused)]
+            source: NtpSourceConfig,
+        }
+
+        let TestConfig {
+            source: NtpSourceConfig::Pps(test),
+        } = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            precision = 0.25
+            period = 1.5
+            "#,
+        )
+        .unwrap()
+        else {
+            panic!("Unexpected source type");
+        };
+        assert_eq!(test.precision, 0.25);
+        assert_eq!(test.period, 1.5);
+
+        let TestConfig {
+            source: NtpSourceConfig::Pps(test),
+        } = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            measurement_noise_estimate = 0.0625
+            "#,
+        )
+        .unwrap()
+        else {
+            panic!("Unexpected source type");
+        };
+        assert_eq!(test.precision, 0.25);
+        assert_eq!(test.period, 1.0);
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            precision = 0.25
+            measurement_noise_estimate = 0.0625
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            precision = 0.25
+            unknown_field = 5
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            precision = -0.25
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            measurement_noise_estimate = -0.0625
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            precision = -0.25
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            precision = 0.25
+            period = -0.5
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            measurement_noise_estimate = 0.0
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            precision = 0.0
+            "#,
+        );
+        assert!(test.is_err());
+
+        let test: Result<TestConfig, _> = toml::from_str(
+            r#"
+            [source]
+            mode = "pps"
+            path = "/test/path"
+            precision = 0.25
+            period = 0.0
+            "#,
+        );
+        assert!(test.is_err());
     }
 
     #[test]

--- a/ntpd/src/daemon/spawn/pps.rs
+++ b/ntpd/src/daemon/spawn/pps.rs
@@ -41,7 +41,7 @@ impl Spawner for PpsSpawner {
                     id: SourceId::new(),
                     path: self.config.path.clone(),
                     config: self.source_config,
-                    noise_estimate: self.config.measurement_noise_estimate,
+                    noise_estimate: self.config.precision.powi(2),
                     period: self.config.period,
                 })),
             ))
@@ -94,11 +94,11 @@ mod tests {
     #[tokio::test]
     async fn creates_a_source() {
         let socket_path = std::env::temp_dir().join(format!("ntp-test-stream-{}", alloc_port()));
-        let noise_estimate = 1e-6;
+        let precision = 1e-3;
         let mut spawner = PpsSpawner::new(
             PpsSourceConfig {
                 path: socket_path.clone(),
-                measurement_noise_estimate: noise_estimate,
+                precision,
                 period: 1.,
             },
             SourceConfig::default(),
@@ -118,7 +118,7 @@ mod tests {
             panic!("did not receive PPS source create parameters!");
         };
         assert_eq!(params.path, socket_path);
-        assert!((params.noise_estimate - noise_estimate).abs() < 1e-9);
+        assert!((params.noise_estimate - precision.powi(2)).abs() < 1e-9);
 
         // Should be complete after spawning
         assert!(spawner.is_complete());

--- a/ntpd/src/daemon/spawn/sock.rs
+++ b/ntpd/src/daemon/spawn/sock.rs
@@ -41,7 +41,7 @@ impl Spawner for SockSpawner {
                     id: SourceId::new(),
                     path: self.config.path.clone(),
                     config: self.source_config,
-                    noise_estimate: self.config.measurement_noise_estimate,
+                    noise_estimate: self.config.precision.powi(2),
                 })),
             ))
             .await?;
@@ -93,11 +93,11 @@ mod tests {
     #[tokio::test]
     async fn creates_a_source() {
         let socket_path = std::env::temp_dir().join(format!("ntp-test-stream-{}", alloc_port()));
-        let noise_estimate = 1e-6;
+        let precision = 1e-3;
         let mut spawner = SockSpawner::new(
             SockSourceConfig {
                 path: socket_path.clone(),
-                measurement_noise_estimate: noise_estimate,
+                precision,
             },
             SourceConfig::default(),
         );
@@ -116,7 +116,7 @@ mod tests {
             panic!("did not receive sock source create parameters!");
         };
         assert_eq!(params.path, socket_path);
-        assert!((params.noise_estimate - noise_estimate).abs() < 1e-9);
+        assert!((params.noise_estimate - precision.powi(2)).abs() < 1e-9);
 
         // Should be complete after spawning
         assert!(spawner.is_complete());


### PR DESCRIPTION
This involves deprecating a field, we should check that this is the way we want to proceed.

Reasoning is that precision as given in a 1-stddev bound is a much more intuitive notion than measurement variance. These numbers can be interpreted as (parts of) seconds, which makes their values a  lot nicer.