### PR TITLE
Code coverage for the fuzzers

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -270,6 +270,56 @@ jobs:
             cargo fuzz run ${{ matrix.features }} $target -- -max_total_time=10
           done
 
+  fuzz-code-coverage:
+    name: Fuzz with code coverage
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - fuzz_target: packet_parsing_sound
+            corpus: ""
+            features: ''
+          - fuzz_target: record_encode_decode
+            corpus: ""
+            features: ''
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+      - name: Install cargo fuzz & rustfilt
+        uses: taiki-e/install-action@56ab7930c591507f833cbaed864d201386d518a8
+        with:
+          tool: cargo-fuzz,rustfilt
+      - name: Run `cargo fuzz`
+        env:
+          RUST_BACKTRACE: "1"
+          # prevents `cargo fuzz coverage` from rebuilding everything
+          RUSTFLAGS: "-C instrument-coverage"
+        run: |
+          cargo fuzz run ${{matrix.features}} ${{matrix.fuzz_target}} ${{matrix.corpus}} -- -max_total_time=10
+      - name: Fuzz codecov
+        run: |
+          cargo fuzz coverage ${{matrix.features}} ${{matrix.fuzz_target}} ${{matrix.corpus}}
+          $(rustc --print sysroot)/lib/rustlib/$(rustc --print host-tuple)/bin/llvm-cov export -Xdemangler=rustfilt \
+              target/$(rustc --print host-tuple)/coverage/$(rustc --print host-tuple)/release/${{matrix.fuzz_target}} \
+              -instr-profile=fuzz/coverage/${{matrix.fuzz_target}}/coverage.profdata \
+              --format=lcov \
+              -ignore-filename-regex="\.cargo|\.rustup" > lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+        with:
+          files: ./lcov.info
+          fail_ci_if_error: false
+          flags: fuzz-${{ matrix.fuzz_target }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: fuzz
+
   audit-dependencies:
     name: Audit dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -99,11 +99,15 @@ jobs:
         env:
           RUST_BACKTRACE: 1
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+        if: matrix.rust == 'stable'
         with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./lcov.info
           fail_ci_if_error: false
+          flags: test-${{matrix.target}}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: test
+          verbose: true
 
   unused:
     name: Check unused dependencies


### PR DESCRIPTION
Backporting lessons from zlib-rs

The comment below has a table with the flags (see dropdown). The coverage percentage itself is not too interesting, but the delta may be in the future. The real advantage is that you can now see whether the fuzzer actually hits the logic you expect.

Doing some clicking through the interface, this is the coverage for `fuzz-packet_parsing_sound`: https://app.codecov.io/github/pendulum-project/ntpd-rs/commit/b560a6393de61168dde532292c01bf5480e22af9/tree/ntp-proto/src?flags%5B0%5D=fuzz-packet_parsing_sound&dropdown=coverage

E.g. here you can see  that the fuzzer is unable to generate a valid `NtsEncryptedField`:

https://app.codecov.io/github/pendulum-project/ntpd-rs/commit/b560a6393de61168dde532292c01bf5480e22af9/blob/ntp-proto/src/packet/extension_fields.rs?flags%5B0%5D=fuzz-packet_parsing_sound&dropdown=coverage#L660

At this point I'm not that familiar with the details of the codebase, so you'll have to look at the results here to see if anything jumps out. It's straightforward to add more fuzzers, and they all run in parallel so CI time does not increase if you do so.
