### PR TITLE
Changed kalman offset message to debug level

### DIFF
--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -143,7 +143,7 @@ impl<C: NtpClock, SourceId: Hash + Eq + Copy + Debug> KalmanClockController<C, S
         );
 
         if let Some(combined) = combine(&selection, &self.algo_config) {
-            info!(
+            debug!(
                 "Offset: {}+-{}ms, frequency: {}+-{}ppm",
                 combined.estimate.offset() * 1e3,
                 combined.estimate.offset_variance().sqrt() * 1e3,


### PR DESCRIPTION
After deploying `ntpd-rs` on my systems, the system logs are peppered with:

```
ntp-daemon[2022]: 2025-04-28T22:16:44.902268Z  INFO ntp_proto::algorithm::kalman: Offset: -9.71569488420898+-5.958433943105912ms, frequency: -0.029784204729893793+-1.5403756385090928pp
```

Which isn't useful to the average system admin, hence reduce this message to `debug`.