### PR TITLE
metrics: Drop high cardinality 'id' label from metric collection

### DIFF
--- a/ntpd/src/metrics/mod.rs
+++ b/ntpd/src/metrics/mod.rs
@@ -101,7 +101,6 @@ macro_rules! collect_sources {
             let labels = vec![
                 ("name", $ident.name.clone()),
                 ("address", $ident.address.clone()),
-                ("id", format!("{}", $ident.id)),
             ];
             let value = $value;
             data.push(Measurement { labels, value });
@@ -118,7 +117,6 @@ macro_rules! collect_some_sources {
                 let labels = vec![
                     ("name", $ident.name.clone()),
                     ("address", $ident.address.clone()),
-                    ("id", format!("{}", $ident.id)),
                 ];
                 data.push(Measurement { labels, value });
             }


### PR DESCRIPTION
This creates a new time series record for every single request ID that's sent to every NTP server: https://prometheus.io/docs/practices/naming/#labels