### PR TITLE
Do coverage analysis of fuzzing results

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -270,6 +270,56 @@ jobs:
             cargo fuzz run ${{ matrix.features }} $target -- -max_total_time=10
           done
 
+  fuzz-code-coverage:
+    name: Fuzz with code coverage
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - fuzz_target: packet_parsing_sound
+            corpus: ""
+            features: ''
+          - fuzz_target: record_encode_decode
+            corpus: ""
+            features: ''
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+      - name: Install cargo fuzz & rustfilt
+        uses: taiki-e/install-action@56ab7930c591507f833cbaed864d201386d518a8
+        with:
+          tool: cargo-fuzz,rustfilt
+      - name: Run `cargo fuzz`
+        env:
+          RUST_BACKTRACE: "1"
+          # prevents `cargo fuzz coverage` from rebuilding everything
+          RUSTFLAGS: "-C instrument-coverage"
+        run: |
+          cargo fuzz run ${{matrix.features}} ${{matrix.fuzz_target}} ${{matrix.corpus}} -- -max_total_time=10
+      - name: Fuzz codecov
+        run: |
+          cargo fuzz coverage ${{matrix.features}} ${{matrix.fuzz_target}} ${{matrix.corpus}}
+          $(rustc --print sysroot)/lib/rustlib/$(rustc --print host-tuple)/bin/llvm-cov export -Xdemangler=rustfilt \
+              target/$(rustc --print host-tuple)/coverage/$(rustc --print host-tuple)/release/${{matrix.fuzz_target}} \
+              -instr-profile=fuzz/coverage/${{matrix.fuzz_target}}/coverage.profdata \
+              --format=lcov \
+              -ignore-filename-regex="\.cargo|\.rustup" > lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+        with:
+          files: ./lcov.info
+          fail_ci_if_error: false
+          flags: fuzz-${{ matrix.fuzz_target }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: fuzz
+
   audit-dependencies:
     name: Audit dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -242,40 +242,39 @@ jobs:
         run: cargo clippy --target ${{matrix.target}} --manifest-path ./fuzz/fuzz_rand_shim/Cargo.toml --all-targets -- -D warnings
         if: ${{matrix.fuzzer}}
 
-  fuzz:
-    name: Smoke-test fuzzing targets
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        features:
-          - ""
-          - "--all-features"
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          persist-credentials: false
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
-        with:
-          toolchain: nightly
-      - name: Install cargo fuzz
-        uses: taiki-e/cache-cargo-install-action@4d586f211d9b0bca9e7b59e57e2a0febf36c0929 # v2.1.1
-        with:
-          tool: cargo-fuzz
-      - name: Smoke-test fuzz targets
-        run: |
-          cargo fuzz build ${{ matrix.features }}
-          for target in $(cargo fuzz list) ; do
-            cargo fuzz run ${{ matrix.features }} $target -- -max_total_time=10
-          done
-
   fuzz-code-coverage:
     name: Fuzz with code coverage
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
+          - fuzz_target: cookie_parsing_sound
+            corpus: ""
+            features: ''
+          - fuzz_target: duration_from_float
+            corpus: ""
+            features: ''
+          - fuzz_target: encrypted_client_parsing
+            corpus: ""
+            features: ''
+          - fuzz_target: encrypted_server_parsing
+            corpus: ""
+            features: ''
+          - fuzz_target: ipfilter
+            corpus: ""
+            features: ''
+          - fuzz_target: key_exchange_result_decoder
+            corpus: ""
+            features: ''
+          - fuzz_target: key_exchange_server_decoder
+            corpus: ""
+            features: ''
+          - fuzz_target: ntsrecord
+            corpus: ""
+            features: ''
+          - fuzz_target: packet_keyset
+            corpus: ""
+            features: ''
           - fuzz_target: packet_parsing_sound
             corpus: ""
             features: ''

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -99,11 +99,15 @@ jobs:
         env:
           RUST_BACKTRACE: 1
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        if: matrix.rust == 'stable'
         with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./lcov.info
           fail_ci_if_error: false
+          flags: test-${{matrix.target}}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: test
+          verbose: true
 
   unused:
     name: Check unused dependencies


### PR DESCRIPTION
Based on #1873 by @folkertdev . This makes it work on all fuzzers, and removes the old job.

Note: Before merging this will require rejigging of the required checks for the merge queue.