### PR TITLE
Updated ntpv5 support to draft 4.

### DIFF
--- a/ntp-proto/src/algorithm/kalman/combiner.rs
+++ b/ntp-proto/src/algorithm/kalman/combiner.rs
@@ -13,21 +13,23 @@ fn vote_leap<Index: Copy>(selection: &[SourceSnapshot<Index>]) -> Option<NtpLeap
     let mut votes_59 = 0;
     let mut votes_61 = 0;
     let mut votes_none = 0;
+    let mut votes_unknown = 0;
     for snapshot in selection {
         match snapshot.leap_indicator {
             NtpLeapIndicator::NoWarning => votes_none += 1,
             NtpLeapIndicator::Leap61 => votes_61 += 1,
             NtpLeapIndicator::Leap59 => votes_59 += 1,
-            NtpLeapIndicator::Unknown => {
+            NtpLeapIndicator::Unknown => votes_unknown += 1,
+            NtpLeapIndicator::Unsynchronized => {
                 panic!("Unsynchronized source selected for synchronization!")
             }
         }
     }
-    if votes_none * 2 > selection.len() {
+    if votes_none * 2 > selection.len() - votes_unknown {
         Some(NtpLeapIndicator::NoWarning)
-    } else if votes_59 * 2 > selection.len() {
+    } else if votes_59 * 2 > selection.len() - votes_unknown {
         Some(NtpLeapIndicator::Leap59)
-    } else if votes_61 * 2 > selection.len() {
+    } else if votes_61 * 2 > selection.len() - votes_unknown {
         Some(NtpLeapIndicator::Leap61)
     } else {
         None

--- a/ntp-proto/src/packet/mod.rs
+++ b/ntp-proto/src/packet/mod.rs
@@ -34,7 +34,11 @@ pub enum NtpLeapIndicator {
     NoWarning,
     Leap61,
     Leap59,
+    // Unknown and unsynchronized have the same wire representation, and weren't distinguished in NTPv4.
+    // however, NTPv5 provides a distinction which we need in some parts of the code. For now, we just use
+    // this to encode both, but long term we might want a different approach here.
     Unknown,
+    Unsynchronized,
 }
 
 impl NtpLeapIndicator {
@@ -45,7 +49,7 @@ impl NtpLeapIndicator {
             0 => NtpLeapIndicator::NoWarning,
             1 => NtpLeapIndicator::Leap61,
             2 => NtpLeapIndicator::Leap59,
-            3 => NtpLeapIndicator::Unknown,
+            3 => NtpLeapIndicator::Unsynchronized,
             // This function should only ever be called from the packet parser
             // with just two bits, so this really should be unreachable
             _ => unreachable!(),
@@ -58,11 +62,12 @@ impl NtpLeapIndicator {
             NtpLeapIndicator::Leap61 => 1,
             NtpLeapIndicator::Leap59 => 2,
             NtpLeapIndicator::Unknown => 3,
+            NtpLeapIndicator::Unsynchronized => 3,
         }
     }
 
     pub fn is_synchronized(&self) -> bool {
-        !matches!(self, Self::Unknown)
+        !matches!(self, Self::Unsynchronized)
     }
 }
 

--- a/ntpd/src/daemon/clock.rs
+++ b/ntpd/src/daemon/clock.rs
@@ -69,6 +69,7 @@ impl NtpClock for NtpClockWrapper {
             ntp_proto::NtpLeapIndicator::Leap61 => clock_steering::LeapIndicator::Leap61,
             ntp_proto::NtpLeapIndicator::Leap59 => clock_steering::LeapIndicator::Leap59,
             ntp_proto::NtpLeapIndicator::Unknown => clock_steering::LeapIndicator::Unknown,
+            ntp_proto::NtpLeapIndicator::Unsynchronized => clock_steering::LeapIndicator::Unknown,
         })
     }
 }


### PR DESCRIPTION
Note that between draft 2 and 4, the interpretation of the unknown leap flag changed to indicate synchronization status. Most of the code in this PR is here to deal with that change. The solution taken is not the most elegant, but for now I think the best option.