### PR TITLE
Do access control for pools on domain name basis.

### DIFF
--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -35,7 +35,7 @@ ntp-proto = { workspace = true, features = ["__internal-test",] }
 tokio-rustls.workspace = true
 
 [features]
-default = [ "pps" ]
+default = [ "pps", "unstable_nts-pool" ]
 hardware-timestamping = []
 unstable_nts-pool = ["ntp-proto/nts-pool"]
 pps = [ "dep:pps-time" ]

--- a/ntpd/src/daemon/config/server.rs
+++ b/ntpd/src/daemon/config/server.rs
@@ -198,7 +198,10 @@ pub struct NtsKeConfig {
     pub private_key_path: PathBuf,
     #[serde(default)]
     #[cfg(feature = "unstable_nts-pool")]
-    pub authorized_pool_server_certificates: Vec<PathBuf>,
+    pub additional_pool_ca_certificates: Vec<PathBuf>,
+    #[serde(default)]
+    #[cfg(feature = "unstable_nts-pool")]
+    pub accepted_pool_domains: Vec<String>,
     #[serde(default = "default_nts_ke_timeout")]
     pub key_exchange_timeout_ms: u64,
     #[serde(default = "default_concurrent_connections")]
@@ -413,14 +416,20 @@ mod tests {
             listen = "0.0.0.0:4460"
             certificate-chain-path = "/foo/bar/baz.pem"
             private-key-path = "spam.der"
-            authorized-pool-server-certificates = [ "foo.pem", "bar.pem" ]
+            additional-pool-ca-certificates = [ "foo.pem", "bar.pem" ]
+            accepted-pool-domains = ["a.test", "b.test"]
             "#,
         )
         .unwrap();
 
         assert_eq!(
-            test.nts_ke_server.authorized_pool_server_certificates,
+            test.nts_ke_server.additional_pool_ca_certificates,
             vec![PathBuf::from("foo.pem"), PathBuf::from("bar.pem")]
+        );
+
+        assert_eq!(
+            test.nts_ke_server.accepted_pool_domains,
+            vec!["a.test".to_string(), "b.test".to_string()]
         );
     }
 }


### PR DESCRIPTION
This is somewhat easier in actual deployments, since then the certificates across the pool need not be identical and can be changed with some ease.