### PR TITLE
Stop locking cargo-generate-rpm to a specific version.

### DIFF
--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install cross, cargo-deb and cargo-generate-rpm
         uses: taiki-e/install-action@7b20dfd705618832f20d29066e34aa2f2f6194c2
         with:
-          tool: cross, cargo-deb, cargo-generate-rpm@0.14.0
+          tool: cross, cargo-deb, cargo-generate-rpm
 
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
This is needed because of the new rust edition.