### PR TITLE
Update to NTPv5 draft 05

### DIFF
--- a/ntp-proto/src/packet/v5/mod.rs
+++ b/ntp-proto/src/packet/v5/mod.rs
@@ -14,7 +14,7 @@ pub use error::V5Error;
 
 use super::RequestIdentifier;
 
-pub(crate) const DRAFT_VERSION: &str = "draft-ietf-ntp-ntpv5-04";
+pub(crate) const DRAFT_VERSION: &str = "draft-ietf-ntp-ntpv5-05";
 pub(crate) const UPGRADE_TIMESTAMP: NtpTimestamp = NtpTimestamp::from_bits(*b"NTP5DRFT");
 
 #[repr(u8)]


### PR DESCRIPTION
There were no changes needed in our code as far as I could see (see [datatracker history diff](https://datatracker.ietf.org/doc/draft-ietf-ntp-ntpv5/) for more information).

Closes #1934 