### PR TITLE
Fix force sync failing with single source.

### DIFF
--- a/ntpd/src/force_sync/algorithm.rs
+++ b/ntpd/src/force_sync/algorithm.rs
@@ -107,7 +107,7 @@ impl<C: NtpClock> SingleShotController<C> {
             let mut sum = 0.0;
             let mut count = 0;
             for source in self.sources.values() {
-                if source.get_offset().abs_diff(peak_offset) < Self::ASSUMED_UNCERTAINTY {
+                if source.get_offset().abs_diff(peak_offset) <= Self::ASSUMED_UNCERTAINTY {
                     count += 1;
                     sum += source.get_offset().to_seconds()
                 }


### PR DESCRIPTION
The check needs to be inclusive otherwise the source that provides the bound of the peak region gets incorrectly ignored.