### PR TITLE
Fix compilation failure with "pps" feature disabled

### DIFF
--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -479,6 +479,7 @@ impl Config {
 
         if self.sources.iter().any(|config| match config {
             NtpSourceConfig::Sock(_) => false,
+            #[cfg(feature = "pps")]
             NtpSourceConfig::Pps(_) => false,
             NtpSourceConfig::Standard(config) => {
                 matches!(config.first.ntp_version, ProtocolVersion::V5)


### PR DESCRIPTION
The `NtpSourceConfig::Pps` enum variant is referenced twice in `ntpd/src/daemon/config/mod.rs`, but only properly cfg-gated `#[cfg(feature = "pps")]` once. This PR fixes this issue and the compilation failure if the "pps" feature is not enabled.

See also https://github.com/pendulum-project/pps-time/issues/1 where it was suggested to build ntpd-rs to avoid potential issues with the pps-time crate.
