### PR TITLE
Enable the too-many-lines lint.

### DIFF
--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -97,6 +97,8 @@ pub struct KalmanClockController<C: NtpClock, SourceId: Hash + Eq + Copy + Debug
 }
 
 impl<C: NtpClock, SourceId: Hash + Eq + Copy + Debug> KalmanClockController<C, SourceId> {
+    // FIXME: Figure out a way to simplify and/or split this function.
+    #[expect(clippy::too_many_lines)]
     fn update_clock(
         &mut self,
         time: NtpTimestamp,

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -982,6 +982,10 @@ impl<
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Long tests are not really a big problem"
+)]
 mod tests {
     use crate::{packet::NtpLeapIndicator, time_types::NtpInstant};
 

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -117,7 +117,7 @@
 #![warn(clippy::string_add_assign)]
 #![warn(clippy::struct_excessive_bools)]
 //FIXME: Enable #![warn(clippy::struct_field_names)]
-//FIXME: Enable #![warn(clippy::too_many_lines)]
+#![warn(clippy::too_many_lines)]
 #![warn(clippy::transmute_ptr_to_ptr)]
 //FIXME: Enable #![warn(clippy::trivially_copy_pass_by_ref)]
 #![warn(clippy::unchecked_duration_subtraction)]

--- a/ntp-proto/src/nts/messages.rs
+++ b/ntp-proto/src/nts/messages.rs
@@ -37,6 +37,8 @@ pub enum Request<'a> {
 }
 
 impl Request<'_> {
+    // FIXME: Figure out a way to simplify and/or split this function.
+    #[expect(clippy::too_many_lines)]
     pub async fn parse(reader: impl AsyncRead + Unpin) -> Result<Self, NtsError> {
         let mut reader = reader.take(MAX_MESSAGE_SIZE);
 
@@ -513,6 +515,10 @@ impl SupportsResponse<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Long tests are not really a big problem"
+)]
 mod tests {
     use std::{
         future::Future,

--- a/ntp-proto/src/nts/mod.rs
+++ b/ntp-proto/src/nts/mod.rs
@@ -475,6 +475,8 @@ impl KeyExchangeServer {
         })
     }
 
+    // FIXME: Figure out a way to simplify and/or split this function.
+    #[expect(clippy::too_many_lines)]
     pub async fn handle_longterm<T: AsyncRead + AsyncWrite + Unpin, U: AsRef<KeySet>>(
         &self,
         mut io: tokio_rustls::server::TlsStream<T>,
@@ -612,6 +614,8 @@ impl KeyExchangeServer {
         }
     }
 
+    // FIXME: Figure out a way to simplify or split this function
+    #[expect(clippy::too_many_lines)]
     pub async fn handle_connection<IO: AsyncRead + AsyncWrite + Unpin, P>(
         &self,
         io: IO,
@@ -835,6 +839,10 @@ impl KeyExchangeServer {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Long tests are not really a big problem"
+)]
 mod tests {
     use super::*;
 

--- a/ntp-proto/src/packet/mod.rs
+++ b/ntp-proto/src/packet/mod.rs
@@ -297,7 +297,9 @@ impl<'a> NtpPacket<'a> {
         }
     }
 
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
+    // FIXME: Figure out a way to simplify and/or split this function.
+    #[expect(clippy::too_many_lines)]
     pub fn deserialize(
         data: &'a [u8],
         cipher: &(impl CipherProvider + ?Sized),
@@ -1363,6 +1365,10 @@ impl Default for NtpPacket<'_> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Long tests are not really a big problem"
+)]
 mod tests {
     use crate::{
         keyset::KeySetProvider, nts::AeadAlgorithm, system::TimeSnapshot,

--- a/ntp-proto/src/server.rs
+++ b/ntp-proto/src/server.rs
@@ -170,6 +170,8 @@ impl<C: NtpClock> Server<C> {
     /// If the buffer isn't large enough to encode the reply, this
     /// will log an error and ignore the incoming packet. A buffer
     /// as large as the message will always suffice.
+    // FIXME: Figure out a way to simplify or split this function
+    #[expect(clippy::too_many_lines)]
     pub fn handle<'a>(
         &mut self,
         client_ip: IpAddr,
@@ -433,6 +435,10 @@ impl<'de> Deserialize<'de> for IpSubnet {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Long tests are not really a big problem"
+)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -868,6 +868,10 @@ impl<Controller: SourceController<MeasurementDelay = NtpDuration>> NtpSource<Con
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Long tests are not really a big problem"
+)]
 mod test {
     use crate::{
         NtpClock,

--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -566,6 +566,10 @@ impl From<toml::de::Error> for ConfigError {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Long tests are not really a big problem"
+)]
 mod tests {
     use ntp_proto::{NtpDuration, ProtocolVersion, StepThreshold};
 

--- a/ntpd/src/daemon/config/ntp_source.rs
+++ b/ntpd/src/daemon/config/ntp_source.rs
@@ -653,6 +653,10 @@ impl<'a> TryFrom<&'a str> for NtpSourceConfig {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Long tests are not really a big problem"
+)]
 mod tests {
     use super::*;
 

--- a/ntpd/src/daemon/ntp_source.rs
+++ b/ntpd/src/daemon/ntp_source.rs
@@ -116,6 +116,8 @@ where
         SocketResult::Ok
     }
 
+    // FIXME: Figure out reasonable ways to simplify and/or split this function
+    #[expect(clippy::too_many_lines)]
     async fn run(&mut self, mut poll_wait: Pin<&mut T>) {
         loop {
             let mut buf = [0_u8; 1024];

--- a/ntpd/src/lib.rs
+++ b/ntpd/src/lib.rs
@@ -110,7 +110,7 @@
 #![warn(clippy::string_add_assign)]
 //FIXME: Enable #![warn(clippy::struct_excessive_bools)]
 #![warn(clippy::struct_field_names)]
-//FIXME: Enable #![warn(clippy::too_many_lines)]
+#![warn(clippy::too_many_lines)]
 #![warn(clippy::transmute_ptr_to_ptr)]
 #![warn(clippy::trivially_copy_pass_by_ref)]
 //FIXME: Enable #![warn(clippy::unchecked_duration_subtraction)]

--- a/ntpd/src/metrics/mod.rs
+++ b/ntpd/src/metrics/mod.rs
@@ -139,6 +139,9 @@ macro_rules! collect_servers {
     }};
 }
 
+// Allow this function to be oversized as it is otherwise straightforward
+// and has no reasonable way to be split.
+#[expect(clippy::too_many_lines)]
 pub fn format_state(w: &mut impl std::fmt::Write, state: &ObservableState) -> std::fmt::Result {
     format_metric(
         w,


### PR DESCRIPTION
Note that this does not fix any function. Instead, we mark any violations with expect attributes and a fixme comment.

There is one exception to this in that we mark format_state in ntpd/src/metrics/mod.rs as explicitly allowed to be too long, as it is long but not that complex and has no reasonable splitting points left.