### PR TITLE
Use expect to provide local exceptions to lints instead of allow.

### DIFF
--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -680,7 +680,6 @@ impl<D: Debug + Copy + Clone, N: MeasurementNoiseEstimator<MeasurementDelay = D>
 }
 
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
 enum SourceStateInner<
     D: Debug + Copy + Clone,
     N: MeasurementNoiseEstimator<MeasurementDelay = D> + Clone,

--- a/ntp-proto/src/nts/messages.rs
+++ b/ntp-proto/src/nts/messages.rs
@@ -589,7 +589,6 @@ mod tests {
                 assert_eq!(algorithms, [AeadAlgorithm::AeadAesSivCmac256].as_slice());
                 assert_eq!(protocols, [NextProtocol::NTPv4].as_slice());
             }
-            #[allow(unreachable_patterns)]
             _ => panic!("Unexpected misparse of message"),
         }
 
@@ -613,7 +612,6 @@ mod tests {
                     [NextProtocol::DraftNTPv5, NextProtocol::NTPv4].as_slice()
                 );
             }
-            #[allow(unreachable_patterns)]
             _ => panic!("Unexpected misparse of message"),
         }
     }
@@ -735,7 +733,6 @@ mod tests {
                 assert_eq!(algorithms, [AeadAlgorithm::AeadAesSivCmac256].as_slice());
                 assert_eq!(protocols, [NextProtocol::NTPv4].as_slice());
             }
-            #[allow(unreachable_patterns)]
             _ => panic!("Unexpected misparse of message"),
         }
 
@@ -756,7 +753,6 @@ mod tests {
                 assert_eq!(algorithms, [AeadAlgorithm::AeadAesSivCmac256].as_slice());
                 assert_eq!(protocols, [NextProtocol::NTPv4].as_slice());
             }
-            #[allow(unreachable_patterns)]
             _ => panic!("Unexpected misparse of message"),
         }
 
@@ -777,7 +773,6 @@ mod tests {
                 assert_eq!(algorithms, [AeadAlgorithm::AeadAesSivCmac256].as_slice());
                 assert_eq!(protocols, [NextProtocol::NTPv4].as_slice());
             }
-            #[allow(unreachable_patterns)]
             _ => panic!("Unexpected misparse of message"),
         }
 
@@ -798,7 +793,6 @@ mod tests {
                 assert_eq!(algorithms, [AeadAlgorithm::AeadAesSivCmac256].as_slice());
                 assert_eq!(protocols, [NextProtocol::NTPv4].as_slice());
             }
-            #[allow(unreachable_patterns)]
             _ => panic!("Unexpected misparse of message"),
         }
 
@@ -819,7 +813,6 @@ mod tests {
                 assert_eq!(algorithms, [AeadAlgorithm::AeadAesSivCmac256].as_slice());
                 assert_eq!(protocols, [NextProtocol::NTPv4].as_slice());
             }
-            #[allow(unreachable_patterns)]
             _ => panic!("Unexpected misparse of message"),
         }
     }
@@ -845,7 +838,6 @@ mod tests {
                 assert_eq!(protocols, [NextProtocol::NTPv4].as_slice());
                 assert_eq!(denied_servers, ["hi"].as_slice());
             }
-            #[allow(unreachable_patterns)]
             _ => panic!("Unexpected misparse of message"),
         }
     }

--- a/ntp-proto/src/nts/record.rs
+++ b/ntp-proto/src/nts/record.rs
@@ -309,7 +309,7 @@ impl NtsRecord<'_> {
     fn record_type(&self) -> u16 {
         const CRITICAL_BIT: u16 = 0x8000;
         match self {
-            #[allow(clippy::identity_op)]
+            #[expect(clippy::identity_op)]
             NtsRecord::EndOfMessage => 0 | CRITICAL_BIT,
             NtsRecord::NextProtocol { .. } => 1 | CRITICAL_BIT,
             NtsRecord::Error { .. } => 2 | CRITICAL_BIT,

--- a/ntp-proto/src/packet/extension_fields.rs
+++ b/ntp-proto/src/packet/extension_fields.rs
@@ -592,7 +592,6 @@ impl<'a> ExtensionFieldData<'a> {
         Ok(())
     }
 
-    #[allow(clippy::type_complexity)]
     pub(super) fn deserialize(
         data: &'a [u8],
         header_size: usize,

--- a/ntp-proto/src/packet/v5/extension_fields.rs
+++ b/ntp-proto/src/packet/v5/extension_fields.rs
@@ -134,9 +134,6 @@ impl<'a> ReferenceIdResponse<'a> {
         }
     }
 
-    // TODO: Clippy 0.1.86 complains that this function could be const, but that is not true
-    // allow can be removed in later versions
-    #[allow(clippy::missing_const_for_fn)]
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }

--- a/ntp-proto/src/packet/v5/mod.rs
+++ b/ntp-proto/src/packet/v5/mod.rs
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn parse_request() {
-        #[allow(clippy::unusual_byte_groupings)] // Bits are grouped by fields
+        #[expect(clippy::unusual_byte_groupings)] // Bits are grouped by fields
         #[rustfmt::skip]
         let data = [
             // LI VN  Mode
@@ -439,7 +439,7 @@ mod tests {
 
     #[test]
     fn parse_response() {
-        #[allow(clippy::unusual_byte_groupings)] // Bits are grouped by fields
+        #[expect(clippy::unusual_byte_groupings)] // Bits are grouped by fields
         #[rustfmt::skip]
         let data = [
             // LI VN  Mode
@@ -512,7 +512,7 @@ mod tests {
 
     #[test]
     fn parse_response_unsynchronized() {
-        #[allow(clippy::unusual_byte_groupings)] // Bits are grouped by fields
+        #[expect(clippy::unusual_byte_groupings)] // Bits are grouped by fields
         #[rustfmt::skip]
         let data = [
             // LI VN  Mode
@@ -623,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::unusual_byte_groupings)] // Bits are grouped by fields
+    #[expect(clippy::unusual_byte_groupings)] // Bits are grouped by fields
     fn fail_on_incorrect_version() {
         let mut data: [u8; 48] = [0u8; 48];
         data[0] = 0b_00_111_100;

--- a/ntp-proto/src/source.rs
+++ b/ntp-proto/src/source.rs
@@ -231,7 +231,7 @@ pub struct OneWaySourceUpdate<SourceMessage> {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum SourceSnapshot {
     Ntp(NtpSourceSnapshot),
     OneWay(OneWaySourceSnapshot),
@@ -418,7 +418,7 @@ impl<SourceMessage> NtpSourceUpdate<SourceMessage> {
 }
 
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum NtpSourceAction<SourceMessage> {
     /// Send a message over the network. When this is issued, the network port maybe changed.
     Send(Vec<u8>),

--- a/ntp-proto/src/system.rs
+++ b/ntp-proto/src/system.rs
@@ -155,7 +155,6 @@ impl<ControllerMessage: Clone> Clone for SystemSourceUpdate<ControllerMessage> {
 }
 
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
 pub enum SystemAction<ControllerMessage> {
     UpdateSources(SystemSourceUpdate<ControllerMessage>),
     SetTimer(Duration),
@@ -297,7 +296,7 @@ impl<SourceId: Hash + Eq + Copy + Debug, Controller: TimeSyncController<SourceId
         Ok(OneWaySource::new(controller))
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn create_ntp_source(
         &mut self,
         id: SourceId,

--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -841,7 +841,7 @@ mod tests {
     fn duration_not_nan() {
         #[derive(Debug, Deserialize)]
         struct Helper {
-            #[allow(unused)]
+            #[expect(unused)]
             duration: NtpDuration,
         }
 
@@ -859,7 +859,7 @@ mod tests {
     fn step_threshold_not_nan() {
         #[derive(Debug, Deserialize)]
         struct Helper {
-            #[allow(unused)]
+            #[expect(unused)]
             threshold: StepThreshold,
         }
 

--- a/ntpd/src/daemon/ntp_source.rs
+++ b/ntpd/src/daemon/ntp_source.rs
@@ -30,7 +30,7 @@ impl Wait for Sleep {
 }
 
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum MsgForSystem<SourceMessage> {
     /// Received a Kiss-o'-Death and must demobilize
     MustDemobilize(SourceId),
@@ -122,7 +122,6 @@ where
         loop {
             let mut buf = [0_u8; 1024];
 
-            #[allow(clippy::large_enum_variant)]
             enum SelectResult<Controller: SourceController> {
                 Timer,
                 Recv(Result<RecvResult<SocketAddr>, std::io::Error>),
@@ -334,7 +333,7 @@ impl<C, Controller: SourceController<MeasurementDelay = NtpDuration>>
 where
     C: 'static + NtpClock + Send + Sync,
 {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     #[instrument(level = tracing::Level::ERROR, name = "Ntp Source", skip(timestamp_mode, clock, channels, source, initial_actions))]
     pub fn spawn(
         index: SourceId,

--- a/ntpd/src/daemon/pps_source.rs
+++ b/ntpd/src/daemon/pps_source.rs
@@ -140,7 +140,6 @@ where
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     #[instrument(level = tracing::Level::ERROR, name = "Pps Source", skip(clock, channels, source))]
     pub fn spawn(
         index: SourceId,

--- a/ntpd/src/daemon/sock_source.rs
+++ b/ntpd/src/daemon/sock_source.rs
@@ -206,7 +206,6 @@ where
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     #[instrument(level = tracing::Level::ERROR, name = "Sock Source", skip(clock, channels, source))]
     pub fn spawn(
         index: SourceId,

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -217,7 +217,7 @@ struct SystemTask<
 impl<C: NtpClock + Sync, Controller: TimeSyncController<Clock = C, SourceId = SourceId>, T: Wait>
     SystemTask<C, Controller, T>
 {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         clock: C,
         interface: Option<InterfaceName>,


### PR DESCRIPTION
This has the advantage that we are forced to clean up the exceptions once they are no longer necessary, as happened for a number of allow's in this commit.