### PR TITLE
Enable range-plus-one clippy lint.

### DIFF
--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -98,7 +98,7 @@
 #![warn(clippy::ptr_cast_constness)]
 #![warn(clippy::pub_underscore_fields)]
 #![warn(clippy::range_minus_one)]
-//FIXME: Enable #![warn(clippy::range_plus_one)]
+#![warn(clippy::range_plus_one)]
 //FIXME: Enable #![warn(clippy::redundant_closure_for_method_calls)]
 //FIXME: Enable #![warn(clippy::redundant_else)]
 #![warn(clippy::ref_as_ptr)]

--- a/ntp-proto/src/packet/v5/server_reference_id.rs
+++ b/ntp-proto/src/packet/v5/server_reference_id.rs
@@ -380,7 +380,7 @@ mod tests {
                 continue;
             };
 
-            for _chunk in 0..((512 / chunk_size) + 1) {
+            for _chunk in 0..=(512 / chunk_size) {
                 let cookie = NtpClientCookie::new_random();
                 let request = bf.next_request(cookie);
                 let response = request.to_response(&target_filter).unwrap();


### PR DESCRIPTION
Includes single fix that was necessary for this.