### PR TITLE
Explicitly allow redundant_else clippy lint.

### DIFF
--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -100,7 +100,10 @@
 #![warn(clippy::range_minus_one)]
 #![warn(clippy::range_plus_one)]
 #![warn(clippy::redundant_closure_for_method_calls)]
-//FIXME: Enable #![warn(clippy::redundant_else)]
+#![allow(
+    clippy::redundant_else,
+    reason = "We prefer the style this warns against"
+)]
 #![warn(clippy::ref_as_ptr)]
 #![warn(clippy::ref_binding_to_reference)]
 #![warn(clippy::ref_option)]

--- a/ntpd/src/lib.rs
+++ b/ntpd/src/lib.rs
@@ -93,7 +93,10 @@
 #![warn(clippy::range_minus_one)]
 #![warn(clippy::range_plus_one)]
 #![warn(clippy::redundant_closure_for_method_calls)]
-//FIXME: Enable #![warn(clippy::redundant_else)]
+#![allow(
+    clippy::redundant_else,
+    reason = "We prefer the style this warns against"
+)]
 #![warn(clippy::ref_as_ptr)]
 #![warn(clippy::ref_binding_to_reference)]
 #![warn(clippy::ref_option)]


### PR DESCRIPTION
This is motivated by the fact that I prefer the clarity of either A or B happens in the situations where this lint triggers. The tradeoff of slightly more indentation is in my opinion not problematic.

Note: Commit message is formulated to reflect that this is shared consensus after accepting this PR