### PR TITLE
Restart ntpd-rs via systemd

### DIFF
--- a/docs/examples/conf/ntpd-rs.service
+++ b/docs/examples/conf/ntpd-rs.service
@@ -7,7 +7,7 @@ Conflicts=systemd-timesyncd.service ntp.service chrony.service
 
 [Service]
 Type=simple
-Restart=no
+Restart=always
 ExecStart=/usr/bin/ntp-daemon
 Environment="RUST_LOG=info"
 RuntimeDirectory=ntpd-rs


### PR DESCRIPTION
As `ntpd-rs` can panic by design, set its systemd unit to always restart it.

If `ntpd-rs` runs in server mode, it makes a lot of sense to get it serving users again ASAP (vs requiring manual intervention).

If it runs in client mode, it's probably still preferred to make attempts to correct the time if it's too far off.

I couldn't find anything in git history on why it's set to `no` but it would perhaps be a good idea to reconsider this. We can discuss this here. 