### PR TITLE
Allow configuration of accuracy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [main]
+
+### Added
+- Allow configuration of pps and sock source accuracy in addition to precision.
+
 ## [1.7.1]
 
 ### Changed
@@ -337,6 +342,8 @@ process.
 - Fixed a bug in peer dispersion calculation which resulted in overly
   pessimistic dispersion estimates.
 
+[main]: https://github.com/pendulum-project/ntpd-rs/compare/v1.7.1...main
+[1.7.1]: https://github.com/pendulum-project/ntpd-rs/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/pendulum-project/ntpd-rs/compare/v1.6.2...v1.7.0
 [1.6.2]: https://github.com/pendulum-project/ntpd-rs/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/pendulum-project/ntpd-rs/compare/v1.6.0...v1.6.1

--- a/docs/guide/gps-pps.md
+++ b/docs/guide/gps-pps.md
@@ -23,7 +23,9 @@ path = "/run/ntpd-rs/chrony.XXXX.sock"
 precision = 1e-3
 ```
 
-For socket sources such as a GPS device from gpsd, ntpd-rs is unable to estimate the uncertainty of the timing data. Therefore, you should provide an estimate (corresponding to 1 standard deviation) of this noise yourself through the `precision` field. For typical GPS receivers, an uncertainty somewhere in the range of 1 to 100 ms is reasonable.
+For socket sources such as a GPS device from gpsd, ntpd-rs is unable to estimate the uncertainty of the timing data. Therefore, you must provide an estimate (corresponding to 1 standard deviation) of this noise yourself through the `precision` field. For typical GPS receivers, an uncertainty somewhere in the range of 1 to 100 ms is reasonable.
+
+In addition, an accuracy can also be configured for sock sources. This allows you to deprioritize sock sources which have larger offset, or for whom the quality of the GPS signal is not particularly good. These are then still used for consensus of what time it should be, but have far less impact on the actual synchronization.
 
 ### Setting up GPSd
 In order for GPSd to connect to ntpd-rs, GPSd must start after ntpd-rs and after the socket shim has been created. This is because ntpd-rs needs to create the socket for GPSd, which can only find the socket if it exists at the moment GPSd starts.

--- a/docs/man/ntp.toml.5.md
+++ b/docs/man/ntp.toml.5.md
@@ -120,6 +120,13 @@ sources.
     1-standard deviation bound on the measurement error. This is needed as
     `sock` and `pps` sources don't have a good way to estimate their own error.
 
+`accuracy` = *Uncertainty standard deviation (seconds)*
+:   `pps` and `sock` mode only. Accuracy of the underlying time source. This should
+    be an estimate of the size of the error in the clock you are synchronizing with,
+    as well as any mostly-unchanging offset in the measurement process. This can be
+    used to deprioritize sources which have large offsets in the measurement process
+    or which are of poorer quality than others.
+
 `poll-interval-limits` = { `min` = *min*, `max` = *max* } (defaults from `[source-defaults]`)
 :   Specifies the limit on how often a source is queried for a new time. For
     most instances the defaults will be adequate. The min and max are given as

--- a/docs/precompiled/man/ntp.toml.5
+++ b/docs/precompiled/man/ntp.toml.5
@@ -160,6 +160,15 @@ error.
 This is needed as \f[V]sock\f[R] and \f[V]pps\f[R] sources don\[cq]t
 have a good way to estimate their own error.
 .TP
+\f[V]accuracy\f[R] = \f[I]Uncertainty standard deviation (seconds)\f[R]
+\f[V]pps\f[R] and \f[V]sock\f[R] mode only.
+Accuracy of the underlying time source.
+This should be an estimate of the size of the error in the clock you are
+synchronizing with, as well as any mostly-unchanging offset in the
+measurement process.
+This can be used to deprioritize sources which have large offsets in the
+measurement process or which are of poorer quality than others.
+.TP
 \f[V]poll-interval-limits\f[R] = { \f[V]min\f[R] = \f[I]min\f[R], \f[V]max\f[R] = \f[I]max\f[R] } (defaults from \f[V][source-defaults]\f[R])
 Specifies the limit on how often a source is queried for a new time.
 For most instances the defaults will be adequate.

--- a/ntp-proto/src/algorithm/kalman/mod.rs
+++ b/ntp-proto/src/algorithm/kalman/mod.rs
@@ -5,6 +5,7 @@ use source::OneWayKalmanSourceController;
 use tracing::{debug, error, info, warn};
 
 use crate::{
+    algorithm::kalman::source::FixedMeasurementNoise,
     clock::NtpClock,
     config::{SourceConfig, SynchronizationConfig},
     packet::NtpLeapIndicator,
@@ -424,6 +425,7 @@ impl<C: NtpClock, SourceId: Hash + Eq + Copy + Debug + Send + 'static> TimeSyncC
         id: SourceId,
         source_config: SourceConfig,
         measurement_noise_estimate: f64,
+        measurement_accuracy_estimate: f64,
         period: Option<f64>,
     ) -> Self::OneWaySourceController {
         self.sources.insert(id, (None, false));
@@ -432,7 +434,10 @@ impl<C: NtpClock, SourceId: Hash + Eq + Copy + Debug + Send + 'static> TimeSyncC
             self.algo_config,
             period,
             source_config,
-            measurement_noise_estimate,
+            FixedMeasurementNoise {
+                precision: measurement_noise_estimate,
+                accuracy: measurement_accuracy_estimate,
+            },
         )
     }
 

--- a/ntp-proto/src/algorithm/kalman/source.rs
+++ b/ntp-proto/src/algorithm/kalman/source.rs
@@ -358,13 +358,19 @@ impl MeasurementNoiseEstimator for AveragingBuffer {
     }
 }
 
-impl MeasurementNoiseEstimator for f64 {
+#[derive(Debug, Clone, Copy)]
+pub struct FixedMeasurementNoise {
+    pub(super) precision: f64,
+    pub(super) accuracy: f64,
+}
+
+impl MeasurementNoiseEstimator for FixedMeasurementNoise {
     type MeasurementDelay = ();
 
     fn update(&mut self, _delay: Self::MeasurementDelay) {}
 
     fn get_noise_estimate(&self) -> f64 {
-        *self
+        self.precision
     }
 
     fn is_outlier(&self, _delay: Self::MeasurementDelay, _threshold: f64) -> bool {
@@ -378,11 +384,12 @@ impl MeasurementNoiseEstimator for f64 {
     }
 
     fn get_max_roundtrip(&self, _samples: &i32) -> Option<f64> {
-        Some(1.)
+        Some(1.0f64.max(self.accuracy))
     }
 
     fn get_delay_mean(&self) -> f64 {
-        0.
+        // Bit of a hack: multiply by 4 to compensate for the low delay weight. This is because accuracy doesn't quite map to delay.
+        4.0 * self.accuracy
     }
 }
 
@@ -896,7 +903,8 @@ pub struct KalmanSourceController<
 pub type TwoWayKalmanSourceController<SourceId> =
     KalmanSourceController<SourceId, NtpDuration, AveragingBuffer>;
 
-pub type OneWayKalmanSourceController<SourceId> = KalmanSourceController<SourceId, (), f64>;
+pub type OneWayKalmanSourceController<SourceId> =
+    KalmanSourceController<SourceId, (), FixedMeasurementNoise>;
 
 impl<
     SourceId: Copy,
@@ -1361,7 +1369,13 @@ mod tests {
 
     #[test]
     fn test_offset_steering_and_measurements_constant_noise_estimate() {
-        test_offset_steering_and_measurements(1e-9, ());
+        test_offset_steering_and_measurements(
+            FixedMeasurementNoise {
+                precision: 1e-9,
+                accuracy: 0.0,
+            },
+            (),
+        );
     }
 
     #[test]
@@ -2068,7 +2082,13 @@ mod tests {
 
     #[test]
     fn test_init_constant_noise_estimate() {
-        test_init(1e-3, ());
+        test_init(
+            FixedMeasurementNoise {
+                precision: 1e-3,
+                accuracy: 0.0,
+            },
+            (),
+        );
     }
 
     #[test]

--- a/ntp-proto/src/algorithm/mod.rs
+++ b/ntp-proto/src/algorithm/mod.rs
@@ -88,6 +88,7 @@ pub trait TimeSyncController: Sized + Send + 'static {
         id: Self::SourceId,
         source_config: SourceConfig,
         measurement_noise_estimate: f64,
+        measurement_accuracy_estimate: f64,
         period: Option<f64>,
     ) -> Self::OneWaySourceController;
     /// Notify the controller that a previous source has gone

--- a/ntp-proto/src/system.rs
+++ b/ntp-proto/src/system.rs
@@ -263,14 +263,19 @@ impl<SourceId: Hash + Eq + Copy + Debug, Controller: TimeSyncController<SourceId
         id: SourceId,
         source_config: SourceConfig,
         measurement_noise_estimate: f64,
+        measurement_accuracy_estimate: f64,
     ) -> Result<
         OneWaySource<Controller::OneWaySourceController>,
         <Controller::Clock as NtpClock>::Error,
     > {
         self.ensure_controller_control()?;
-        let controller =
-            self.controller
-                .add_one_way_source(id, source_config, measurement_noise_estimate, None);
+        let controller = self.controller.add_one_way_source(
+            id,
+            source_config,
+            measurement_noise_estimate,
+            measurement_accuracy_estimate,
+            None,
+        );
         self.sources.insert(id, None);
         Ok(OneWaySource::new(controller))
     }
@@ -280,6 +285,7 @@ impl<SourceId: Hash + Eq + Copy + Debug, Controller: TimeSyncController<SourceId
         id: SourceId,
         source_config: SourceConfig,
         measurement_noise_estimate: f64,
+        measurement_accuracy_estimate: f64,
         period: f64,
     ) -> Result<
         OneWaySource<Controller::OneWaySourceController>,
@@ -290,6 +296,7 @@ impl<SourceId: Hash + Eq + Copy + Debug, Controller: TimeSyncController<SourceId
             id,
             source_config,
             measurement_noise_estimate,
+            measurement_accuracy_estimate,
             Some(period),
         );
         self.sources.insert(id, None);

--- a/ntpd/src/daemon/config/ntp_source.rs
+++ b/ntpd/src/daemon/config/ntp_source.rs
@@ -159,6 +159,7 @@ pub struct NtsPoolSourceConfig {
 pub struct SockSourceConfig {
     pub path: PathBuf,
     pub precision: f64,
+    pub accuracy: f64,
 }
 
 impl<'de> Deserialize<'de> for SockSourceConfig {
@@ -171,6 +172,7 @@ impl<'de> Deserialize<'de> for SockSourceConfig {
         enum Field {
             Path,
             Precision,
+            Accuracy,
             MeasurementNoiseEstimate,
         }
 
@@ -189,6 +191,7 @@ impl<'de> Deserialize<'de> for SockSourceConfig {
             {
                 let mut path = None;
                 let mut precision = None;
+                let mut accuracy = None;
                 while let Some(key) = map.next_key()? {
                     match key {
                         Field::Path => {
@@ -224,21 +227,45 @@ impl<'de> Deserialize<'de> for SockSourceConfig {
                             {
                                 return Err(de::Error::invalid_value(
                                     serde::de::Unexpected::Float(precision_raw),
-                                    &"measurement_noise_estimate should be positive",
+                                    &"precision should be positive",
                                 ));
                             }
                             precision = Some(precision_raw);
+                        }
+                        Field::Accuracy => {
+                            if accuracy.is_some() {
+                                return Err(de::Error::duplicate_field("accuracy"));
+                            }
+                            let accuracy_raw: f64 = map.next_value()?;
+                            if accuracy_raw.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater)
+                            {
+                                return Err(de::Error::invalid_value(
+                                    serde::de::Unexpected::Float(accuracy_raw),
+                                    &"precision should be positive",
+                                ));
+                            }
+                            accuracy = Some(accuracy_raw);
                         }
                     }
                 }
                 let path = path.ok_or_else(|| serde::de::Error::missing_field("path"))?;
                 let precision =
                     precision.ok_or_else(|| serde::de::Error::missing_field("precision"))?;
-                Ok(SockSourceConfig { path, precision })
+                let accuracy = accuracy.unwrap_or(0.0);
+                Ok(SockSourceConfig {
+                    path,
+                    precision,
+                    accuracy,
+                })
             }
         }
 
-        const FIELDS: &[&str] = &["path", "precision", "measurement_noise_estimate"];
+        const FIELDS: &[&str] = &[
+            "path",
+            "precision",
+            "accuracy",
+            "measurement_noise_estimate",
+        ];
         deserializer.deserialize_struct("SockSourceConfig", FIELDS, SockSourceConfigVisitor)
     }
 }
@@ -294,10 +321,12 @@ pub struct FlattenedPair<T, U> {
 pub struct PpsSourceConfig {
     pub path: PathBuf,
     pub precision: f64,
+    pub accuracy: f64,
     pub period: f64,
 }
 
 impl<'de> Deserialize<'de> for PpsSourceConfig {
+    #[expect(clippy::too_many_lines, reason = "Deserializers can be a bit wordy")]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -307,6 +336,7 @@ impl<'de> Deserialize<'de> for PpsSourceConfig {
         enum Field {
             Path,
             Precision,
+            Accuracy,
             MeasurementNoiseEstimate,
             Period,
         }
@@ -326,6 +356,7 @@ impl<'de> Deserialize<'de> for PpsSourceConfig {
             {
                 let mut path = None;
                 let mut precision = None;
+                let mut accuracy = None;
                 let mut period = None;
                 while let Some(key) = map.next_key()? {
                     match key {
@@ -367,6 +398,20 @@ impl<'de> Deserialize<'de> for PpsSourceConfig {
                             }
                             precision = Some(precision_raw);
                         }
+                        Field::Accuracy => {
+                            if accuracy.is_some() {
+                                return Err(de::Error::duplicate_field("accuracy"));
+                            }
+                            let accuracy_raw: f64 = map.next_value()?;
+                            if accuracy_raw.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater)
+                            {
+                                return Err(de::Error::invalid_value(
+                                    serde::de::Unexpected::Float(accuracy_raw),
+                                    &"precision should be positive",
+                                ));
+                            }
+                            accuracy = Some(accuracy_raw);
+                        }
                         Field::Period => {
                             if period.is_some() {
                                 return Err(de::Error::duplicate_field("period"));
@@ -385,10 +430,12 @@ impl<'de> Deserialize<'de> for PpsSourceConfig {
                 let path = path.ok_or_else(|| serde::de::Error::missing_field("path"))?;
                 let precision =
                     precision.ok_or_else(|| serde::de::Error::missing_field("precision"))?;
+                let accuracy = accuracy.unwrap_or(0.0);
                 let period = period.unwrap_or(1.0);
                 Ok(PpsSourceConfig {
                     path,
                     precision,
+                    accuracy,
                     period,
                 })
             }

--- a/ntpd/src/daemon/sock_source.rs
+++ b/ntpd/src/daemon/sock_source.rs
@@ -335,7 +335,7 @@ mod tests {
                 source_snapshots: Arc::new(RwLock::new(HashMap::new())),
             },
             system
-                .create_sock_source(index, SourceConfig::default(), 0.001)
+                .create_sock_source(index, SourceConfig::default(), 0.001, 1e-3)
                 .unwrap(),
         );
 

--- a/ntpd/src/daemon/spawn/mod.rs
+++ b/ntpd/src/daemon/spawn/mod.rs
@@ -178,7 +178,8 @@ pub struct SockSourceCreateParameters {
     pub id: SourceId,
     pub path: PathBuf,
     pub config: SourceConfig,
-    pub noise_estimate: f64,
+    pub precision: f64,
+    pub accuracy: f64,
 }
 
 #[cfg(feature = "pps")]
@@ -187,7 +188,8 @@ pub struct PpsSourceCreateParameters {
     pub id: SourceId,
     pub path: PathBuf,
     pub config: SourceConfig,
-    pub noise_estimate: f64,
+    pub precision: f64,
+    pub accuracy: f64,
     pub period: f64,
 }
 

--- a/ntpd/src/daemon/spawn/pps.rs
+++ b/ntpd/src/daemon/spawn/pps.rs
@@ -40,7 +40,8 @@ impl Spawner for PpsSpawner {
                     id: SourceId::new(),
                     path: self.config.path.clone(),
                     config: self.source_config,
-                    noise_estimate: self.config.precision.powi(2),
+                    precision: self.config.precision.powi(2),
+                    accuracy: self.config.accuracy,
                     period: self.config.period,
                 })),
             ))
@@ -94,10 +95,12 @@ mod tests {
     async fn creates_a_source() {
         let socket_path = std::env::temp_dir().join(format!("ntp-test-stream-{}", alloc_port()));
         let precision = 1e-3;
+        let accuracy = 1e-3;
         let mut spawner = PpsSpawner::new(
             PpsSourceConfig {
                 path: socket_path.clone(),
                 precision,
+                accuracy,
                 period: 1.,
             },
             SourceConfig::default(),
@@ -117,7 +120,7 @@ mod tests {
             panic!("did not receive PPS source create parameters!");
         };
         assert_eq!(params.path, socket_path);
-        assert!((params.noise_estimate - precision.powi(2)).abs() < 1e-9);
+        assert!((params.precision - precision.powi(2)).abs() < 1e-9);
 
         // Should be complete after spawning
         assert!(spawner.is_complete());

--- a/ntpd/src/daemon/spawn/sock.rs
+++ b/ntpd/src/daemon/spawn/sock.rs
@@ -40,7 +40,8 @@ impl Spawner for SockSpawner {
                     id: SourceId::new(),
                     path: self.config.path.clone(),
                     config: self.source_config,
-                    noise_estimate: self.config.precision.powi(2),
+                    precision: self.config.precision.powi(2),
+                    accuracy: self.config.accuracy,
                 })),
             ))
             .await?;
@@ -93,10 +94,12 @@ mod tests {
     async fn creates_a_source() {
         let socket_path = std::env::temp_dir().join(format!("ntp-test-stream-{}", alloc_port()));
         let precision = 1e-3;
+        let accuracy = 1e-3;
         let mut spawner = SockSpawner::new(
             SockSourceConfig {
                 path: socket_path.clone(),
                 precision,
+                accuracy,
             },
             SourceConfig::default(),
         );
@@ -115,7 +118,7 @@ mod tests {
             panic!("did not receive sock source create parameters!");
         };
         assert_eq!(params.path, socket_path);
-        assert!((params.noise_estimate - precision.powi(2)).abs() < 1e-9);
+        assert!((params.precision - precision.powi(2)).abs() < 1e-9);
 
         // Should be complete after spawning
         assert!(spawner.is_complete());

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -515,7 +515,8 @@ impl<C: NtpClock + Sync, Controller: TimeSyncController<Clock = C, SourceId = So
                 let source = self.system.create_sock_source(
                     source_id,
                     params.config,
-                    params.noise_estimate,
+                    params.precision,
+                    params.accuracy,
                 )?;
                 SockSourceTask::spawn(
                     source_id,
@@ -534,7 +535,8 @@ impl<C: NtpClock + Sync, Controller: TimeSyncController<Clock = C, SourceId = So
                 let source = self.system.create_pps_source(
                     source_id,
                     params.config,
-                    params.noise_estimate,
+                    params.precision,
+                    params.accuracy,
                     params.period,
                 )?;
                 PpsSourceTask::spawn(

--- a/ntpd/src/force_sync/algorithm.rs
+++ b/ntpd/src/force_sync/algorithm.rs
@@ -167,6 +167,7 @@ impl<C: NtpClock> TimeSyncController for SingleShotController<C> {
         _id: Self::SourceId,
         config: SourceConfig,
         _measurement_noise_estimate: f64,
+        _measurement_accuracy_estimate: f64,
         period: Option<f64>,
     ) -> Self::OneWaySourceController {
         SingleShotSourceController::<()> {


### PR DESCRIPTION
This is needed for some GPS sock sources as they can have very large but mostly static offsets. This can make it hard to deprioritize them sufficiently through precision alone, as the synchronization algorithm assumes it can compensate for lack of precision with repeated measurements, which is not true for lack of accuracy.

Fixes #2169 