### PR TITLE
docs: Add dark mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,20 @@
 theme:
   name: material
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
   features:
     - content.tooltips
     - content.code.copy


### PR DESCRIPTION
Close https://github.com/pendulum-project/ntpd-rs/issues/2187

Just add the snippet from the docs of "Material for MkDocs", and we'll get automatic detection for dark or light mode.

https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode

Version:
```
docker run --rm -it -p 8000:8000 -v "$PWD":/docs squidfunk/mkdocs-material --version
mkdocs, version 1.6.1 from /usr/local/lib/python3.11/site-packages/mkdocs (Python 3.11)
```

## Screenshot Dark

<img width="2880" height="1760" alt="image" src="https://github.com/user-attachments/assets/f7fff7e6-e96e-4938-a3e0-f068d4106676" />

## Screenshot Light

Same as before, but with one extra button

<img width="2880" height="1760" alt="image" src="https://github.com/user-attachments/assets/9b2d5f7f-e5a3-4742-bf73-670229b29f52" />