### PR TITLE
clippy: fix needless_raw_string_hashes lint

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 msrv = "1.88"
+allow-one-hash-in-raw-strings = true

--- a/ntpd/src/lib.rs
+++ b/ntpd/src/lib.rs
@@ -81,7 +81,7 @@
 #![warn(clippy::needless_continue)]
 #![warn(clippy::needless_for_each)]
 #![warn(clippy::needless_pass_by_value)]
-//FIXME: Enable #![warn(clippy::needless_raw_string_hashes)]
+#![warn(clippy::needless_raw_string_hashes)]
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::no_mangle_with_rust_abi)]
 #![warn(clippy::non_std_lazy_statics)]


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#needless_raw_string_hashes