### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ntp-proto-fuzz"
 version = "0.0.0"
-authors = ["Automatically generated"]
 edition = "2018"
 publish = false
 


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068