### PR TITLE
Make dependency on AWS-LC optional and allow OpenSSL as an alternative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +979,7 @@ dependencies = [
  "md-5",
  "rand 0.8.6",
  "rustls",
+ "rustls-openssl",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -984,6 +1000,7 @@ dependencies = [
  "pps-time",
  "rand 0.8.6",
  "rustls",
+ "rustls-openssl",
  "serde",
  "serde_json",
  "timestamped-socket",
@@ -1029,10 +1046,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1068,6 +1122,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1269,6 +1329,20 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-openssl"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce63aeefbba181bc32fe7519a3d7edcdfa9fc2aa1f5e7f152493a25275ec14a"
+dependencies = [
+ "foreign-types",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "rustls",
+ "zeroize",
 ]
 
 [[package]]
@@ -1849,6 +1923,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 
 # TLS
 rustls23 = { package = "rustls", version = "0.23.16", default-features = false, features = ["logging", "std", "tls12"] }
+rustls-openssl = "0.3.1"
 rustls-platform-verifier = "0.5.0"
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "tls12"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["std", "fmt", "ansi"] }
 
 # TLS
-rustls23 = { package = "rustls", version = "0.23.16", features = ["logging", "std"] }
+rustls23 = { package = "rustls", version = "0.23.16", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-platform-verifier = "0.5.0"
-tokio-rustls = { version = "0.26.0", features = ["logging"] }
+tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "tls12"] }
 
 # crypto
 aead = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["std", "fmt", "ansi"] }
 
 # TLS
-rustls23 = { package = "rustls", version = "0.23.16", default-features = false, features = ["logging", "std", "tls12"] }
-rustls-openssl = "0.3.1"
+rustls23 = { package = "rustls", version = "0.23.22", default-features = false, features = ["logging", "std", "tls12"] }
+rustls-openssl = ">=0.3.0,<0.9"
 rustls-platform-verifier = "0.5.0"
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "tls12"] }
 
@@ -56,7 +56,7 @@ aead = "0.5.0"
 aes-siv = "0.7.0"
 # Note: md5 is needed to calculate ReferenceIDs for IPv6 addresses per RFC5905
 md-5 = "0.10.0"
-zeroize = "1.7"
+zeroize = "1.8.1"
 
 # development
 serde_test = { version = "1.0.176" }

--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -13,7 +13,8 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["aws-lc"]
+aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
 __internal-fuzz = ["arbitrary", "__internal-api"]
 __internal-test = ["__internal-api"]
 __internal-api = []

--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -15,6 +15,7 @@ rust-version.workspace = true
 [features]
 default = ["aws-lc"]
 aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
+openssl = ["dep:rustls-openssl"]
 __internal-fuzz = ["arbitrary", "__internal-api"]
 __internal-test = ["__internal-api"]
 __internal-api = []
@@ -28,6 +29,7 @@ tokio = { workspace = true, features = ["io-util"] }
 tokio-rustls.workspace = true
 serde.workspace = true
 rustls23.workspace = true
+rustls-openssl = { workspace = true, optional = true }
 rustls-platform-verifier.workspace = true
 arbitrary = { workspace = true, optional = true }
 aead.workspace = true

--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -36,6 +36,11 @@ aead.workspace = true
 aes-siv.workspace = true
 zeroize.workspace = true
 
+[target.'cfg(target_env = "musl")'.dependencies.rustls-openssl]
+workspace = true
+optional = true
+features = ["vendored"]
+
 [dev-dependencies]
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/ntp-proto/src/nts/mod.rs
+++ b/ntp-proto/src/nts/mod.rs
@@ -876,6 +876,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_v4() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -938,6 +941,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_v5() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1000,6 +1006,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_upgrading() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1062,6 +1071,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_no_upgrade_possible() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1124,6 +1136,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_no_proto_overlap() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1170,6 +1185,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_key_exchange_roundtrip_no_cookies() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1227,6 +1245,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_fixed_key() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1330,6 +1351,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_fixed_key_keep_alive() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1452,6 +1476,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_fixed_key_no_permit() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1555,6 +1582,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_fixed_key_no_permission() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1626,6 +1656,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_roundtrip_supports() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {
@@ -1713,6 +1746,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_keyexchange_supports_no_permission() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let (client, server) = tokio::io::duplex(2048);
 
         let client = async move {

--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -35,6 +35,11 @@ rustls-openssl = { workspace = true, optional = true }
 ntp-proto = { workspace = true, features = ["__internal-test",] }
 tokio-rustls.workspace = true
 
+[target.'cfg(target_env = "musl")'.dependencies.rustls-openssl]
+workspace = true
+optional = true
+features = ["vendored"]
+
 [features]
 default = [ "aws-lc", "pps", "srv" ]
 hardware-timestamping = []

--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 ntp-proto.workspace = true
 
-hickory-resolver.workspace = true
+hickory-resolver = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "io-std", "fs", "sync", "net", "macros", "signal"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -35,9 +35,10 @@ ntp-proto = { workspace = true, features = ["__internal-test",] }
 tokio-rustls.workspace = true
 
 [features]
-default = [ "pps" ]
+default = [ "pps", "srv" ]
 hardware-timestamping = []
 pps = [ "dep:pps-time" ]
+srv = [ "dep:hickory-resolver" ]
 
 [package.metadata.deb]
 name = "ntpd-rs"

--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -29,6 +29,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 rustls23.workspace = true
+rustls-openssl = { workspace = true, optional = true }
 
 [dev-dependencies]
 ntp-proto = { workspace = true, features = ["__internal-test",] }
@@ -40,6 +41,7 @@ hardware-timestamping = []
 pps = [ "dep:pps-time" ]
 srv = [ "dep:hickory-resolver" ]
 aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
+openssl = ["dep:rustls-openssl"]
 
 [package.metadata.deb]
 name = "ntpd-rs"

--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -35,10 +35,11 @@ ntp-proto = { workspace = true, features = ["__internal-test",] }
 tokio-rustls.workspace = true
 
 [features]
-default = [ "pps", "srv" ]
+default = [ "aws-lc", "pps", "srv" ]
 hardware-timestamping = []
 pps = [ "dep:pps-time" ]
 srv = [ "dep:hickory-resolver" ]
+aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
 
 [package.metadata.deb]
 name = "ntpd-rs"

--- a/ntpd/src/daemon/dns.rs
+++ b/ntpd/src/daemon/dns.rs
@@ -19,17 +19,30 @@ pub(crate) struct KeResolutionResult {
     pub(crate) srv_record_name: Option<String>,
 }
 
+#[cfg(not(feature = "srv"))]
+pub(crate) async fn resolve_ke(
+    addr: &NormalizedAddress,
+) -> Result<impl Iterator<Item = KeResolutionResult>, std::io::Error> {
+    let lookup_result = lookup_host((addr.server_name.as_str(), addr.port))
+        .await?
+        .map(|addr| KeResolutionResult {
+            addr,
+            srv_record_name: None,
+        });
+
+    Ok(lookup_result)
+}
+
+#[cfg(feature = "srv")]
 pub(crate) async fn resolve_ke(
     addr: &NormalizedAddress,
 ) -> Result<impl Iterator<Item = KeResolutionResult>, std::io::Error> {
     // Kludge allowing us to return two types of iterator.
-    #[cfg(feature = "srv")]
     enum Either<A, B> {
         A(A),
         B(B),
     }
 
-    #[cfg(feature = "srv")]
     impl<A: Iterator<Item = KeResolutionResult>, B: Iterator<Item = KeResolutionResult>> Iterator
         for Either<A, B>
     {
@@ -44,7 +57,6 @@ pub(crate) async fn resolve_ke(
     }
 
     // First try looking up SRV records
-    #[cfg(feature = "srv")]
     if let Ok(srv_names) = resolve_srv(format!("_ntske._tcp.{}", addr.server_name)).await {
         let mut result = vec![];
         for name in srv_names.into_iter().map(|v| v.to_ascii()) {
@@ -68,10 +80,7 @@ pub(crate) async fn resolve_ke(
             srv_record_name: None,
         });
 
-    #[cfg(feature = "srv")]
-    return Ok(Either::B(lookup_result));
-    #[cfg(not(feature = "srv"))]
-    return Ok(lookup_result);
+    Ok(Either::B(lookup_result))
 }
 
 #[cfg(feature = "srv")]

--- a/ntpd/src/daemon/dns.rs
+++ b/ntpd/src/daemon/dns.rs
@@ -1,17 +1,18 @@
-use std::{net::SocketAddr, process::exit, sync::OnceLock};
+use std::net::SocketAddr;
 
+#[cfg(feature = "srv")]
 use hickory_resolver::{
     TokioResolver,
     net::NetError,
     proto::rr::{IntoName, Name},
 };
-use rand::Rng;
 use tokio::net::lookup_host;
 
-use crate::daemon::{config::NormalizedAddress, exitcode};
+use crate::daemon::config::NormalizedAddress;
 
 // We keep the resolver globally to avoid reloading its configuration constantly.
-static RESOLVER: OnceLock<TokioResolver> = OnceLock::new();
+#[cfg(feature = "srv")]
+static RESOLVER: std::sync::OnceLock<TokioResolver> = std::sync::OnceLock::new();
 
 pub(crate) struct KeResolutionResult {
     pub(crate) addr: SocketAddr,
@@ -22,10 +23,13 @@ pub(crate) async fn resolve_ke(
     addr: &NormalizedAddress,
 ) -> Result<impl Iterator<Item = KeResolutionResult>, std::io::Error> {
     // Kludge allowing us to return two types of iterator.
+    #[cfg(feature = "srv")]
     enum Either<A, B> {
         A(A),
         B(B),
     }
+
+    #[cfg(feature = "srv")]
     impl<A: Iterator<Item = KeResolutionResult>, B: Iterator<Item = KeResolutionResult>> Iterator
         for Either<A, B>
     {
@@ -40,6 +44,7 @@ pub(crate) async fn resolve_ke(
     }
 
     // First try looking up SRV records
+    #[cfg(feature = "srv")]
     if let Ok(srv_names) = resolve_srv(format!("_ntske._tcp.{}", addr.server_name)).await {
         let mut result = vec![];
         for name in srv_names.into_iter().map(|v| v.to_ascii()) {
@@ -56,17 +61,25 @@ pub(crate) async fn resolve_ke(
     }
 
     // Otherwise do a direct name lookup
-    Ok(Either::B(
-        lookup_host((addr.server_name.as_str(), addr.port))
-            .await?
-            .map(|addr| KeResolutionResult {
-                addr,
-                srv_record_name: None,
-            }),
-    ))
+    let lookup_result = lookup_host((addr.server_name.as_str(), addr.port))
+        .await?
+        .map(|addr| KeResolutionResult {
+            addr,
+            srv_record_name: None,
+        });
+
+    #[cfg(feature = "srv")]
+    return Ok(Either::B(lookup_result));
+    #[cfg(not(feature = "srv"))]
+    return Ok(lookup_result);
 }
 
+#[cfg(feature = "srv")]
 async fn resolve_srv<N: IntoName>(name: N) -> Result<Vec<Name>, NetError> {
+    use crate::daemon::exitcode;
+    use rand::Rng;
+    use std::process::exit;
+
     let resolver = RESOLVER.get_or_init(|| {
         let mut builder = match TokioResolver::builder_tokio() {
             Ok(builder) => builder,

--- a/ntpd/src/daemon/keyexchange.rs
+++ b/ntpd/src/daemon/keyexchange.rs
@@ -242,6 +242,9 @@ mod tests {
 
     #[tokio::test]
     async fn key_exchange_connection_limiter() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let port = alloc_port();
 
         let provider = KeySetProvider::new(1);
@@ -325,6 +328,9 @@ mod tests {
 
     #[tokio::test]
     async fn key_exchange_roundtrip_with_port_server() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let port = alloc_port();
 
         let provider = KeySetProvider::new(1);

--- a/ntpd/src/daemon/mod.rs
+++ b/ntpd/src/daemon/mod.rs
@@ -38,6 +38,11 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub fn main() -> Result<(), Box<dyn Error>> {
     let options = NtpDaemonOptions::try_parse_from(std::env::args())?;
 
+    #[cfg(feature = "openssl")]
+    rustls_openssl::default_provider()
+        .install_default()
+        .expect("Failed to use rustls_openssl");
+
     match options.action {
         config::NtpDaemonAction::Help => {
             println!("{}", config::long_help_message());

--- a/ntpd/src/daemon/spawn/nts.rs
+++ b/ntpd/src/daemon/spawn/nts.rs
@@ -206,6 +206,9 @@ mod tests {
 
     #[tokio::test]
     async fn direct_name_resolution() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let listener = TcpListener::bind("[::]:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::task::spawn(async move {
@@ -236,6 +239,9 @@ mod tests {
 
     #[tokio::test]
     async fn allow_srv_direct_name_resolution() {
+        #[cfg(feature = "openssl")]
+        let _ = rustls_openssl::default_provider().install_default();
+
         let listener = TcpListener::bind("[::]:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::task::spawn(async move {


### PR DESCRIPTION
This is achieved in three steps (hence three commits)

- First, the hickory resolver is gated behind a feature flag. It has a hard dependency on AWS-LC or `ring` (but using that is not an option)
   - I note with interest that all the unit tests keep working if the `srv` feature flag is disabled; I don't think it's the job of this PR to do anything about that.
   
- Remove the use of `aws-lc` as the CryptoProvider. After this step, one can still (surprising to me) compile everything, but the moment you try to play around with TLS connections without the `aws-lc` feature you hit a `panic!` inside RusTLS.

- Add a gated dependency on `rustls_openssl` and install it very early as the default cryptoprovider.