### PR TITLE
Openssl crypto

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -64,11 +64,11 @@ jobs:
             target: "x86_64-unknown-linux-gnu"
           - rust: "stable"
             os: ubuntu-latest
-            features: "--no-default-features --features openssl"
+            features: "--no-default-features --features openssl-vendored"
             target: "x86_64-unknown-linux-gnu"
           - rust: "stable"
             os: ubuntu-latest
-            features: "--no-default-features --features rustcrypto,openssl"
+            features: "--no-default-features --features rustcrypto,openssl-vendored"
             target: "x86_64-unknown-linux-gnu"
           - rust: "stable"
             os: ubuntu-latest

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -60,7 +60,7 @@ jobs:
             target: "aarch64-apple-darwin"
           - rust: "stable"
             os: ubuntu-latest
-            features: "--no-default-features --features aws-lc"
+            features: "--no-default-features --features rustcrypto,aws-lc"
             target: "x86_64-unknown-linux-gnu"
           - rust: "stable"
             os: ubuntu-latest
@@ -68,11 +68,15 @@ jobs:
             target: "x86_64-unknown-linux-gnu"
           - rust: "stable"
             os: ubuntu-latest
-            features: "--no-default-features --features aws-lc,srv"
+            features: "--no-default-features --features rustcrypto,openssl"
             target: "x86_64-unknown-linux-gnu"
           - rust: "stable"
             os: ubuntu-latest
-            features: "--no-default-features --features aws-lc,pps"
+            features: "--no-default-features --features rustcrypto,aws-lc,srv"
+            target: "x86_64-unknown-linux-gnu"
+          - rust: "stable"
+            os: ubuntu-latest
+            features: "--no-default-features --features rustcrypto,aws-lc,pps"
             target: "x86_64-unknown-linux-gnu"
     steps:
       - name: Checkout sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ dependencies = [
  "aes-siv",
  "arbitrary",
  "md-5",
+ "openssl",
  "rand 0.8.6",
  "rustls",
  "rustls-openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ aes-siv = "0.7.0"
 # Note: md5 is needed to calculate ReferenceIDs for IPv6 addresses per RFC5905
 md-5 = "0.10.0"
 zeroize = "1.8.1"
+# OpenSSL is an alternative crypto provider
+openssl = "0.10.79"
 
 # development
 serde_test = { version = "1.0.176" }

--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -17,6 +17,7 @@ default = ["aws-lc", "rustcrypto"]
 aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
 rustcrypto = ["dep:md-5", "dep:aead", "dep:aes-siv"]
 openssl = ["dep:rustls-openssl", "dep:openssl"]
+openssl-vendored = ["openssl", "rustls-openssl/vendored", "openssl/vendored"]
 __internal-fuzz = ["arbitrary", "__internal-api"]
 __internal-test = ["__internal-api"]
 __internal-api = []
@@ -39,11 +40,6 @@ md-5 = { workspace = true, optional = true }
 aead = { workspace = true, optional = true }
 aes-siv = { workspace = true, optional = true }
 openssl = { workspace = true, optional = true }
-
-[target.'cfg(target_env = "musl")'.dependencies.rustls-openssl]
-workspace = true
-optional = true
-features = ["vendored"]
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -13,16 +13,16 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["aws-lc"]
+default = ["aws-lc", "rustcrypto"]
 aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
-openssl = ["dep:rustls-openssl"]
+rustcrypto = ["dep:md-5"]
+openssl = ["dep:rustls-openssl", "dep:openssl"]
 __internal-fuzz = ["arbitrary", "__internal-api"]
 __internal-test = ["__internal-api"]
 __internal-api = []
 
 [dependencies]
 # Note: md5 is needed to calculate ReferenceIDs for IPv6 addresses per RFC5905
-md-5.workspace = true
 rand.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["io-util"] }
@@ -32,9 +32,13 @@ rustls23.workspace = true
 rustls-openssl = { workspace = true, optional = true }
 rustls-platform-verifier.workspace = true
 arbitrary = { workspace = true, optional = true }
-aead.workspace = true
-aes-siv.workspace = true
 zeroize.workspace = true
+
+# crypto
+md-5 = { workspace = true, optional = true }
+aead = { workspace = true, optional = false }
+aes-siv = { workspace = true, optional = false }
+openssl = { workspace = true, optional = true }
 
 [target.'cfg(target_env = "musl")'.dependencies.rustls-openssl]
 workspace = true

--- a/ntp-proto/Cargo.toml
+++ b/ntp-proto/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [features]
 default = ["aws-lc", "rustcrypto"]
 aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
-rustcrypto = ["dep:md-5"]
+rustcrypto = ["dep:md-5", "dep:aead", "dep:aes-siv"]
 openssl = ["dep:rustls-openssl", "dep:openssl"]
 __internal-fuzz = ["arbitrary", "__internal-api"]
 __internal-test = ["__internal-api"]
@@ -36,8 +36,8 @@ zeroize.workspace = true
 
 # crypto
 md-5 = { workspace = true, optional = true }
-aead = { workspace = true, optional = false }
-aes-siv = { workspace = true, optional = false }
+aead = { workspace = true, optional = true }
+aes-siv = { workspace = true, optional = true }
 openssl = { workspace = true, optional = true }
 
 [target.'cfg(target_env = "musl")'.dependencies.rustls-openssl]

--- a/ntp-proto/src/identifiers.rs
+++ b/ntp-proto/src/identifiers.rs
@@ -1,6 +1,11 @@
 use std::net::IpAddr;
 
+#[cfg(feature = "rustcrypto")]
 use md5::{Digest, Md5};
+
+#[cfg(feature = "openssl")]
+use openssl::hash::{MessageDigest, hash};
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -21,9 +26,14 @@ impl ReferenceId {
     pub fn from_ip(addr: IpAddr) -> ReferenceId {
         match addr {
             IpAddr::V4(addr) => ReferenceId(u32::from_be_bytes(addr.octets())),
-            IpAddr::V6(addr) => ReferenceId(u32::from_be_bytes(
-                Md5::digest(addr.octets())[0..4].try_into().unwrap(),
-            )),
+            IpAddr::V6(addr) => {
+                #[cfg(feature = "rustcrypto")]
+                let digest = Md5::digest(addr.octets());
+                #[cfg(feature = "openssl")]
+                let digest = hash(MessageDigest::md5(), &addr.octets())
+                    .expect("OpenSSL could not compute MD5");
+                ReferenceId(u32::from_be_bytes(digest[0..4].try_into().unwrap()))
+            }
         }
     }
 

--- a/ntp-proto/src/identifiers.rs
+++ b/ntp-proto/src/identifiers.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 #[cfg(feature = "rustcrypto")]
 use md5::{Digest, Md5};
 
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
 use openssl::hash::{MessageDigest, hash};
 
 use serde::{Deserialize, Serialize};
@@ -29,7 +29,7 @@ impl ReferenceId {
             IpAddr::V6(addr) => {
                 #[cfg(feature = "rustcrypto")]
                 let digest = Md5::digest(addr.octets());
-                #[cfg(feature = "openssl")]
+                #[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
                 let digest = hash(MessageDigest::md5(), &addr.octets())
                     .expect("OpenSSL could not compute MD5");
                 ReferenceId(u32::from_be_bytes(digest[0..4].try_into().unwrap()))

--- a/ntp-proto/src/keyset.rs
+++ b/ntp-proto/src/keyset.rs
@@ -53,9 +53,7 @@ impl KeySetProvider {
     pub fn new(history: usize) -> Self {
         KeySetProvider {
             current: Arc::new(KeySet {
-                keys: vec![AesSivCmac512::new(aes_siv::Aes256SivAead::generate_key(
-                    rand::thread_rng(),
-                ))],
+                keys: vec![AesSivCmac512::new_random()],
                 id_offset: 0,
                 primary: 0,
             }),
@@ -77,7 +75,7 @@ impl KeySetProvider {
 
     /// Rotate a new key in as primary, forgetting an old one if needed
     pub fn rotate(&mut self) {
-        let next_key = AesSivCmac512::new(aes_siv::Aes256SivAead::generate_key(rand::thread_rng()));
+        let next_key = AesSivCmac512::new_random();
         let mut keys = Vec::with_capacity((self.history + 1).min(self.current.keys.len() + 1));
         for key in &self.current.keys
             [self.current.keys.len().saturating_sub(self.history)..self.current.keys.len()]

--- a/ntp-proto/src/keyset.rs
+++ b/ntp-proto/src/keyset.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use aead::{KeyInit, generic_array::GenericArray};
+use aead::KeyInit;
 
 use crate::{
     nts::AeadAlgorithm,
@@ -81,9 +81,7 @@ impl KeySetProvider {
             [self.current.keys.len().saturating_sub(self.history)..self.current.keys.len()]
         {
             // This is the rare case where we do really want to make a copy.
-            keys.push(AesSivCmac512::new(GenericArray::clone_from_slice(
-                key.key_bytes(),
-            )));
+            keys.push(AesSivCmac512::from(key.key_bytes()));
         }
         keys.push(next_key);
         self.current = Arc::new(KeySet {
@@ -113,7 +111,7 @@ impl KeySetProvider {
         let mut keys = vec![];
         for _ in 0..len {
             reader.read_exact(&mut buf[0..64])?;
-            keys.push(AesSivCmac512::new(buf.into()));
+            keys.push(AesSivCmac512::from(buf));
         }
         Ok((
             KeySetProvider {
@@ -225,8 +223,8 @@ impl KeySet {
 
                 DecodedServerCookie {
                     algorithm,
-                    s2c: Box::new(AesSivCmac256::new(GenericArray::clone_from_slice(s2c))),
-                    c2s: Box::new(AesSivCmac256::new(GenericArray::clone_from_slice(c2s))),
+                    s2c: Box::new(AesSivCmac256::try_from(s2c).unwrap()),
+                    c2s: Box::new(AesSivCmac256::try_from(c2s).unwrap()),
                 }
             }
             AeadAlgorithm::AeadAesSivCmac512 => {
@@ -240,8 +238,8 @@ impl KeySet {
 
                 DecodedServerCookie {
                     algorithm,
-                    s2c: Box::new(AesSivCmac512::new(GenericArray::clone_from_slice(s2c))),
-                    c2s: Box::new(AesSivCmac512::new(GenericArray::clone_from_slice(c2s))),
+                    s2c: Box::new(AesSivCmac512::from(s2c)),
+                    c2s: Box::new(AesSivCmac512::from(c2s)),
                 }
             }
             AeadAlgorithm::Unknown(_) => return Err(DecryptError),
@@ -251,7 +249,7 @@ impl KeySet {
     #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self {
-            keys: vec![AesSivCmac512::new(std::iter::repeat_n(0, 64).collect())],
+            keys: vec![AesSivCmac512::from(std::iter::repeat_n(0, 64))],
             id_offset: 1,
             primary: 0,
         }
@@ -311,7 +309,7 @@ mod tests {
         };
 
         let keyset = KeySet {
-            keys: vec![AesSivCmac512::new(std::iter::repeat_n(0, 64).collect())],
+            keys: vec![AesSivCmac512::from(std::iter::repeat_n(0, 64))],
             id_offset: 1,
             primary: 0,
         };
@@ -346,12 +344,12 @@ mod tests {
     fn can_decode_cookie_with_padding() {
         let decoded = DecodedServerCookie {
             algorithm: AeadAlgorithm::AeadAesSivCmac512,
-            s2c: Box::new(AesSivCmac512::new((0..64_u8).collect())),
-            c2s: Box::new(AesSivCmac512::new((64..128_u8).collect())),
+            s2c: Box::new(AesSivCmac512::from(0..64_u8)),
+            c2s: Box::new(AesSivCmac512::from(64..128_u8)),
         };
 
         let keyset = KeySet {
-            keys: vec![AesSivCmac512::new(std::iter::repeat_n(0, 64).collect())],
+            keys: vec![AesSivCmac512::from(std::iter::repeat_n(0, 64))],
             id_offset: 1,
             primary: 0,
         };
@@ -369,12 +367,12 @@ mod tests {
     fn roundtrip_aes_siv_cmac_512() {
         let decoded = DecodedServerCookie {
             algorithm: AeadAlgorithm::AeadAesSivCmac512,
-            s2c: Box::new(AesSivCmac512::new((0..64_u8).collect())),
-            c2s: Box::new(AesSivCmac512::new((64..128_u8).collect())),
+            s2c: Box::new(AesSivCmac512::from(0..64_u8)),
+            c2s: Box::new(AesSivCmac512::from((64..128_u8))),
         };
 
         let keyset = KeySet {
-            keys: vec![AesSivCmac512::new(std::iter::repeat_n(0, 64).collect())],
+            keys: vec![AesSivCmac512::from(std::iter::repeat_n(0, 64))],
             id_offset: 1,
             primary: 0,
         };

--- a/ntp-proto/src/keyset.rs
+++ b/ntp-proto/src/keyset.rs
@@ -3,8 +3,6 @@ use std::{
     sync::Arc,
 };
 
-use aead::KeyInit;
-
 use crate::{
     nts::AeadAlgorithm,
     packet::{

--- a/ntp-proto/src/keyset.rs
+++ b/ntp-proto/src/keyset.rs
@@ -81,7 +81,7 @@ impl KeySetProvider {
             [self.current.keys.len().saturating_sub(self.history)..self.current.keys.len()]
         {
             // This is the rare case where we do really want to make a copy.
-            keys.push(AesSivCmac512::from(key.key_bytes()));
+            keys.push(AesSivCmac512::try_from(key.key_bytes()).unwrap());
         }
         keys.push(next_key);
         self.current = Arc::new(KeySet {
@@ -111,7 +111,7 @@ impl KeySetProvider {
         let mut keys = vec![];
         for _ in 0..len {
             reader.read_exact(&mut buf[0..64])?;
-            keys.push(AesSivCmac512::from(buf));
+            keys.push(AesSivCmac512::try_from(buf).unwrap());
         }
         Ok((
             KeySetProvider {
@@ -238,8 +238,8 @@ impl KeySet {
 
                 DecodedServerCookie {
                     algorithm,
-                    s2c: Box::new(AesSivCmac512::from(s2c)),
-                    c2s: Box::new(AesSivCmac512::from(c2s)),
+                    s2c: Box::new(AesSivCmac512::try_from(s2c).unwrap()),
+                    c2s: Box::new(AesSivCmac512::try_from(c2s).unwrap()),
                 }
             }
             AeadAlgorithm::Unknown(_) => return Err(DecryptError),
@@ -249,7 +249,7 @@ impl KeySet {
     #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self {
-            keys: vec![AesSivCmac512::from(std::iter::repeat_n(0, 64))],
+            keys: vec![AesSivCmac512::try_from(std::iter::repeat_n(0, 64)).unwrap()],
             id_offset: 1,
             primary: 0,
         }
@@ -309,7 +309,7 @@ mod tests {
         };
 
         let keyset = KeySet {
-            keys: vec![AesSivCmac512::from(std::iter::repeat_n(0, 64))],
+            keys: vec![AesSivCmac512::try_from(std::iter::repeat_n(0, 64)).unwrap()],
             id_offset: 1,
             primary: 0,
         };
@@ -344,12 +344,12 @@ mod tests {
     fn can_decode_cookie_with_padding() {
         let decoded = DecodedServerCookie {
             algorithm: AeadAlgorithm::AeadAesSivCmac512,
-            s2c: Box::new(AesSivCmac512::from(0..64_u8)),
-            c2s: Box::new(AesSivCmac512::from(64..128_u8)),
+            s2c: Box::new(AesSivCmac512::try_from(0..64_u8).unwrap()),
+            c2s: Box::new(AesSivCmac512::try_from(64..128_u8).unwrap()),
         };
 
         let keyset = KeySet {
-            keys: vec![AesSivCmac512::from(std::iter::repeat_n(0, 64))],
+            keys: vec![AesSivCmac512::try_from(std::iter::repeat_n(0, 64)).unwrap()],
             id_offset: 1,
             primary: 0,
         };
@@ -367,12 +367,12 @@ mod tests {
     fn roundtrip_aes_siv_cmac_512() {
         let decoded = DecodedServerCookie {
             algorithm: AeadAlgorithm::AeadAesSivCmac512,
-            s2c: Box::new(AesSivCmac512::from(0..64_u8)),
-            c2s: Box::new(AesSivCmac512::from((64..128_u8))),
+            s2c: Box::new(AesSivCmac512::try_from(0..64_u8).unwrap()),
+            c2s: Box::new(AesSivCmac512::try_from(64..128_u8).unwrap()),
         };
 
         let keyset = KeySet {
-            keys: vec![AesSivCmac512::from(std::iter::repeat_n(0, 64))],
+            keys: vec![AesSivCmac512::try_from(std::iter::repeat_n(0, 64)).unwrap()],
             id_offset: 1,
             primary: 0,
         };

--- a/ntp-proto/src/lib.rs
+++ b/ntp-proto/src/lib.rs
@@ -140,6 +140,9 @@
 #![warn(clippy::zero_sized_map_values)]
 #![cfg_attr(not(feature = "__internal-api"), allow(unused))]
 
+#[cfg(not(any(feature = "rustcrypto", feature = "openssl")))]
+compile_error!("A crypto provider is needed, use '--features rustcrypto' or '--features openssl'");
+
 mod algorithm;
 mod clock;
 mod config;

--- a/ntp-proto/src/nts/messages.rs
+++ b/ntp-proto/src/nts/messages.rs
@@ -142,15 +142,15 @@ impl Request<'_> {
 
                 let (c2s_key, s2c_key): (Box<dyn Cipher>, Box<dyn Cipher>) = match algorithms[0] {
                     AeadAlgorithm::AeadAesSivCmac256 => match (
-                        AesSivCmac256::from_key_bytes(&key_bytes.0),
-                        AesSivCmac256::from_key_bytes(&key_bytes.1),
+                        AesSivCmac256::try_from(&key_bytes.0),
+                        AesSivCmac256::try_from(&key_bytes.1),
                     ) {
                         (Ok(c2s), Ok(s2c)) => (Box::new(c2s), Box::new(s2c)),
                         _ => return Err(NtsError::IncorrectSizedKey),
                     },
                     AeadAlgorithm::AeadAesSivCmac512 => match (
-                        AesSivCmac512::from_key_bytes(&key_bytes.0),
-                        AesSivCmac512::from_key_bytes(&key_bytes.1),
+                        AesSivCmac512::try_from(&key_bytes.0),
+                        AesSivCmac512::try_from(&key_bytes.1),
                     ) {
                         (Ok(c2s), Ok(s2c)) => (Box::new(c2s), Box::new(s2c)),
                         _ => return Err(NtsError::IncorrectSizedKey),

--- a/ntp-proto/src/nts/messages.rs
+++ b/ntp-proto/src/nts/messages.rs
@@ -142,15 +142,15 @@ impl Request<'_> {
 
                 let (c2s_key, s2c_key): (Box<dyn Cipher>, Box<dyn Cipher>) = match algorithms[0] {
                     AeadAlgorithm::AeadAesSivCmac256 => match (
-                        AesSivCmac256::try_from(&key_bytes.0),
-                        AesSivCmac256::try_from(&key_bytes.1),
+                        AesSivCmac256::try_from(key_bytes.0.as_ref()),
+                        AesSivCmac256::try_from(key_bytes.1.as_ref()),
                     ) {
                         (Ok(c2s), Ok(s2c)) => (Box::new(c2s), Box::new(s2c)),
                         _ => return Err(NtsError::IncorrectSizedKey),
                     },
                     AeadAlgorithm::AeadAesSivCmac512 => match (
-                        AesSivCmac512::try_from(&key_bytes.0),
-                        AesSivCmac512::try_from(&key_bytes.1),
+                        AesSivCmac512::try_from(key_bytes.0.as_ref()),
+                        AesSivCmac512::try_from(key_bytes.1.as_ref()),
                     ) {
                         (Ok(c2s), Ok(s2c)) => (Box::new(c2s), Box::new(s2c)),
                         _ => return Err(NtsError::IncorrectSizedKey),

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -252,20 +252,19 @@ impl AesSivCmac512 {
         Self { key }
     }
 
-    pub fn from(bytes: impl IntoIterator<Item: Borrow<u8>>) -> Self {
-        Self {
-            key: bytes.into_iter().map(|x| *x.borrow()).collect(),
-        }
-    }
-
     pub fn key_size() -> usize {
         // prefer trust in compiler optimisation over trust in mental arithmetic
         Self::new(GenericArray::default()).key.len()
     }
 
-    pub fn try_from(key_bytes: &[u8]) -> Result<Self, KeyError> {
-        (key_bytes.len() == Self::key_size())
-            .then(|| Self::from(key_bytes))
+    pub fn try_from(
+        key_bytes: impl IntoIterator<Item: Borrow<u8>, IntoIter: ExactSizeIterator>,
+    ) -> Result<Self, KeyError> {
+        let bytes = key_bytes.into_iter();
+        (bytes.len() == Self::key_size())
+            .then(|| Self {
+                key: bytes.map(|x| *x.borrow()).collect(),
+            })
             .ok_or(KeyError)
     }
 

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -13,7 +13,7 @@ use super::extension_fields::ExtensionField;
 #[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
 mod openssl_defs;
 #[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
-use openssl_defs::{Aes128Siv, Aes256Siv, Key, SSLName};
+use openssl_defs::{Aes128Siv, Aes256Siv, EVPCipher, Key};
 
 #[derive(Debug)]
 pub struct DecryptError;

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -558,9 +558,14 @@ mod tests {
 
     #[test]
     fn key_functions_correctness() {
-        use aead::KeySizeUser;
-        assert_eq!(Aes128Siv::key_size(), AesSivCmac256::key_size());
-        assert_eq!(Aes256Siv::key_size(), AesSivCmac512::key_size());
+        assert_eq!(
+            std::mem::size_of::<Key<Aes128Siv>>(),
+            AesSivCmac256::key_size()
+        );
+        assert_eq!(
+            std::mem::size_of::<Key<Aes256Siv>>(),
+            AesSivCmac512::key_size()
+        );
 
         let key_bytes = (1..=64).collect::<Vec<u8>>();
         assert!(AesSivCmac256::try_from(&key_bytes).is_err());

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -1,14 +1,20 @@
 use std::borrow::Borrow;
 use std::fmt::Display;
 
-use aead::generic_array::GenericArray;
+#[cfg(feature = "rustcrypto")]
 use aes_siv::{Key, KeyInit, siv::Aes128Siv, siv::Aes256Siv};
+#[cfg(feature = "rustcrypto")]
 use rand::Rng;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::keyset::DecodedServerCookie;
 
 use super::extension_fields::ExtensionField;
+
+#[cfg(feature = "openssl")]
+mod openssl_defs;
+#[cfg(feature = "openssl")]
+use openssl_defs::{Aes128Siv, Aes256Siv, Key};
 
 #[derive(Debug)]
 pub struct DecryptError;
@@ -32,47 +38,10 @@ impl Display for KeyError {
 
 impl std::error::Error for KeyError {}
 
-struct Buffer<'a> {
-    buffer: &'a mut [u8],
-    valid: usize,
-}
-
-impl<'a> Buffer<'a> {
-    fn new(buffer: &'a mut [u8], valid: usize) -> Self {
-        Self { buffer, valid }
-    }
-
-    fn valid(&self) -> usize {
-        self.valid
-    }
-}
-
-impl AsMut<[u8]> for Buffer<'_> {
-    fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.buffer[..self.valid]
-    }
-}
-
-impl AsRef<[u8]> for Buffer<'_> {
-    fn as_ref(&self) -> &[u8] {
-        &self.buffer[..self.valid]
-    }
-}
-
-impl aead::Buffer for Buffer<'_> {
-    fn extend_from_slice(&mut self, other: &[u8]) -> aead::Result<()> {
-        self.buffer
-            .get_mut(self.valid..(self.valid + other.len()))
-            .ok_or(aead::Error)?
-            .copy_from_slice(other);
-        self.valid += other.len();
-        Ok(())
-    }
-
-    fn truncate(&mut self, len: usize) {
-        self.valid = std::cmp::min(self.valid, len);
-    }
-}
+#[cfg(feature = "rustcrypto")]
+mod buffer;
+#[cfg(feature = "rustcrypto")]
+use buffer::Buffer;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EncryptResult {
@@ -169,23 +138,30 @@ impl AesSivCmac256 {
 
     pub fn key_size() -> usize {
         // prefer trust in compiler optimisation over trust in mental arithmetic
-        Self::new(GenericArray::default()).key.len()
+        Self::new(Key::<Aes128Siv>::default()).key.len()
     }
 
     pub fn try_from(key_bytes: &[u8]) -> Result<Self, KeyError> {
-        (key_bytes.len() == Self::key_size())
-            .then(|| Self::new(aead::Key::<Aes128Siv>::clone_from_slice(key_bytes)))
+        let bytes = key_bytes.iter();
+        (bytes.len() == Self::key_size())
+            .then(|| Self {
+                key: bytes.copied().collect(),
+            })
             .ok_or(KeyError)
     }
 }
 
 impl Drop for AesSivCmac256 {
     fn drop(&mut self) {
-        self.key.zeroize();
+        // this is necessary so this code doesn't depend on the
+        // exact static type -- both a GenericArray as a
+        // openssl_defs::Key will implement AsMut.
+        AsMut::<[u8]>::as_mut(&mut self.key).zeroize();
     }
 }
 
 impl Cipher for AesSivCmac256 {
+    #[cfg(feature = "rustcrypto")]
     fn encrypt(
         &self,
         buffer: &mut [u8],
@@ -216,6 +192,7 @@ impl Cipher for AesSivCmac256 {
         })
     }
 
+    #[cfg(feature = "rustcrypto")]
     fn decrypt(
         &self,
         nonce: &[u8],
@@ -227,8 +204,28 @@ impl Cipher for AesSivCmac256 {
             .map_err(|_| DecryptError)
     }
 
+    #[cfg(feature = "openssl")]
+    fn encrypt(
+        &self,
+        buffer: &mut [u8],
+        plaintext_length: usize,
+        associated_data: &[u8],
+    ) -> std::io::Result<EncryptResult> {
+        todo!()
+    }
+
+    #[cfg(feature = "openssl")]
+    fn decrypt(
+        &self,
+        nonce: &[u8],
+        ciphertext: &[u8],
+        associated_data: &[u8],
+    ) -> Result<Vec<u8>, DecryptError> {
+        todo!()
+    }
+
     fn key_bytes(&self) -> &[u8] {
-        &self.key
+        self.key.as_ref()
     }
 }
 
@@ -253,7 +250,7 @@ impl AesSivCmac512 {
 
     pub fn key_size() -> usize {
         // prefer trust in compiler optimisation over trust in mental arithmetic
-        Self::new(GenericArray::default()).key.len()
+        Self::new(Key::<Aes256Siv>::default()).key.len()
     }
 
     pub fn try_from(
@@ -268,9 +265,12 @@ impl AesSivCmac512 {
     }
 
     pub fn new_random() -> Self {
-        Self {
-            key: aes_siv::Aes256SivAead::generate_key(rand::thread_rng()),
-        }
+        #[cfg(feature = "rustcrypto")]
+        let key = aes_siv::Aes256SivAead::generate_key(rand::thread_rng());
+        #[cfg(feature = "openssl")]
+        let key = todo!();
+
+        Self { key }
     }
 }
 
@@ -278,11 +278,13 @@ impl ZeroizeOnDrop for AesSivCmac512 {}
 
 impl Drop for AesSivCmac512 {
     fn drop(&mut self) {
-        self.key.zeroize();
+        // see above
+        AsMut::<[u8]>::as_mut(&mut self.key).zeroize();
     }
 }
 
 impl Cipher for AesSivCmac512 {
+    #[cfg(feature = "rustcrypto")]
     fn encrypt(
         &self,
         buffer: &mut [u8],
@@ -313,6 +315,7 @@ impl Cipher for AesSivCmac512 {
         })
     }
 
+    #[cfg(feature = "rustcrypto")]
     fn decrypt(
         &self,
         nonce: &[u8],
@@ -324,8 +327,28 @@ impl Cipher for AesSivCmac512 {
             .map_err(|_| DecryptError)
     }
 
+    #[cfg(feature = "openssl")]
+    fn encrypt(
+        &self,
+        buffer: &mut [u8],
+        plaintext_length: usize,
+        associated_data: &[u8],
+    ) -> std::io::Result<EncryptResult> {
+        todo!()
+    }
+
+    #[cfg(feature = "openssl")]
+    fn decrypt(
+        &self,
+        nonce: &[u8],
+        ciphertext: &[u8],
+        associated_data: &[u8],
+    ) -> Result<Vec<u8>, DecryptError> {
+        todo!()
+    }
+
     fn key_bytes(&self) -> &[u8] {
-        &self.key
+        self.key.as_ref()
     }
 }
 

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -10,9 +10,9 @@ use crate::keyset::DecodedServerCookie;
 
 use super::extension_fields::ExtensionField;
 
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
 mod openssl_defs;
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
 use openssl_defs::{Aes128Siv, Aes256Siv, Key, SSLName};
 
 #[derive(Debug)]
@@ -213,7 +213,7 @@ impl Cipher for AesSivCmac256 {
             .map_err(|_| DecryptError)
     }
 
-    #[cfg(feature = "openssl")]
+    #[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
     fn encrypt(
         &self,
         buffer: &mut [u8],
@@ -237,7 +237,7 @@ impl Cipher for AesSivCmac256 {
         })
     }
 
-    #[cfg(feature = "openssl")]
+    #[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
     fn decrypt(
         &self,
         nonce: &[u8],
@@ -291,7 +291,7 @@ impl AesSivCmac512 {
     pub fn new_random() -> Self {
         #[cfg(feature = "rustcrypto")]
         let key = aes_siv::Aes256SivAead::generate_key(rand::thread_rng());
-        #[cfg(feature = "openssl")]
+        #[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
         let key = {
             //NOTE: call sites for this function don't expect failure, maybe that should be adjusted
             let mut key_data = Key::<Aes256Siv>::default();
@@ -353,7 +353,7 @@ impl Cipher for AesSivCmac512 {
             .map_err(|_| DecryptError)
     }
 
-    #[cfg(feature = "openssl")]
+    #[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
     fn encrypt(
         &self,
         buffer: &mut [u8],
@@ -377,7 +377,7 @@ impl Cipher for AesSivCmac512 {
         })
     }
 
-    #[cfg(feature = "openssl")]
+    #[cfg(all(feature = "openssl", not(feature = "rustcrypto")))]
     fn decrypt(
         &self,
         nonce: &[u8],

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -173,7 +173,7 @@ impl AesSivCmac256 {
 
     pub fn from_key_bytes(key_bytes: &[u8]) -> Result<Self, KeyError> {
         (key_bytes.len() == Self::key_size())
-            .then(|| Self::new(*aead::Key::<Aes128Siv>::from_slice(key_bytes)))
+            .then(|| Self::new(aead::Key::<Aes128Siv>::clone_from_slice(key_bytes)))
             .ok_or(KeyError)
     }
 }
@@ -256,8 +256,12 @@ impl AesSivCmac512 {
 
     pub fn from_key_bytes(key_bytes: &[u8]) -> Result<Self, KeyError> {
         (key_bytes.len() == Self::key_size())
-            .then(|| Self::new(*aead::Key::<Aes256Siv>::from_slice(key_bytes)))
+            .then(|| Self::new(aead::Key::<Aes256Siv>::clone_from_slice(key_bytes)))
             .ok_or(KeyError)
+    }
+
+    pub fn new_random() -> Self {
+        Self::new(aes_siv::Aes256SivAead::generate_key(rand::thread_rng()))
     }
 }
 

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::fmt::Display;
 
 use aead::generic_array::GenericArray;
@@ -243,8 +244,6 @@ pub struct AesSivCmac512 {
     // the number of bits of security (aes_siv crate)
     key: Key<Aes256Siv>,
 }
-
-use std::borrow::Borrow;
 
 impl AesSivCmac512 {
     // this is necessary for call sites where we want to use type-driven inference

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -3,7 +3,6 @@ use std::fmt::Display;
 
 #[cfg(feature = "rustcrypto")]
 use aes_siv::{Key, KeyInit, siv::Aes128Siv, siv::Aes256Siv};
-#[cfg(feature = "rustcrypto")]
 use rand::Rng;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -14,7 +13,7 @@ use super::extension_fields::ExtensionField;
 #[cfg(feature = "openssl")]
 mod openssl_defs;
 #[cfg(feature = "openssl")]
-use openssl_defs::{Aes128Siv, Aes256Siv, Key};
+use openssl_defs::{Aes128Siv, Aes256Siv, Key, SSLName};
 
 #[derive(Debug)]
 pub struct DecryptError;
@@ -160,6 +159,23 @@ impl Drop for AesSivCmac256 {
     }
 }
 
+/// Prepare the buffer for in place encryption by moving the plaintext
+/// back, creating space for the nonce.
+/// And place the nonce where the caller expects it
+fn prepend_nonce<'a>(
+    buffer: &'a mut [u8],
+    length: usize,
+    nonce: &[u8],
+) -> std::io::Result<&'a mut [u8]> {
+    if buffer.len() < nonce.len() + length {
+        return Err(std::io::ErrorKind::WriteZero.into());
+    }
+    buffer.copy_within(..length, nonce.len());
+    buffer[..nonce.len()].copy_from_slice(nonce);
+
+    Ok(&mut buffer[nonce.len()..])
+}
+
 impl Cipher for AesSivCmac256 {
     #[cfg(feature = "rustcrypto")]
     fn encrypt(
@@ -171,18 +187,11 @@ impl Cipher for AesSivCmac256 {
         let mut siv = Aes128Siv::new(&self.key);
         let nonce: [u8; 16] = rand::thread_rng().r#gen();
 
-        // Prepare the buffer for in place encryption by moving the plaintext
-        // back, creating space for the nonce.
-        if buffer.len() < nonce.len() + plaintext_length {
-            return Err(std::io::ErrorKind::WriteZero.into());
-        }
-        buffer.copy_within(..plaintext_length, nonce.len());
-        // And place the nonce where the caller expects it
-        buffer[..nonce.len()].copy_from_slice(&nonce);
+        let buffer = prepend_nonce(buffer, plaintext_length, &nonce)?;
 
         // Create a wrapper around the plaintext portion of the buffer that has
         // the methods aes_siv needs to do encryption in-place.
-        let mut buffer_wrap = Buffer::new(&mut buffer[nonce.len()..], plaintext_length);
+        let mut buffer_wrap = Buffer::new(buffer, plaintext_length);
         siv.encrypt_in_place([associated_data, &nonce], &mut buffer_wrap)
             .map_err(|_| std::io::ErrorKind::Other)?;
 
@@ -211,7 +220,21 @@ impl Cipher for AesSivCmac256 {
         plaintext_length: usize,
         associated_data: &[u8],
     ) -> std::io::Result<EncryptResult> {
-        todo!()
+        let nonce: [u8; 16] = rand::thread_rng().r#gen();
+
+        let buffer = prepend_nonce(buffer, plaintext_length, &nonce)?;
+
+        let ciphertext_length = openssl_defs::encrypt_in_place(
+            &self.key,
+            buffer,
+            plaintext_length,
+            [associated_data, nonce.as_slice()],
+        )?;
+
+        Ok(EncryptResult {
+            nonce_length: nonce.len(),
+            ciphertext_length,
+        })
     }
 
     #[cfg(feature = "openssl")]
@@ -221,7 +244,8 @@ impl Cipher for AesSivCmac256 {
         ciphertext: &[u8],
         associated_data: &[u8],
     ) -> Result<Vec<u8>, DecryptError> {
-        todo!()
+        openssl_defs::decrypt_vec(&self.key, ciphertext, [associated_data, nonce])
+            .map_err(|_| DecryptError)
     }
 
     fn key_bytes(&self) -> &[u8] {
@@ -268,7 +292,16 @@ impl AesSivCmac512 {
         #[cfg(feature = "rustcrypto")]
         let key = aes_siv::Aes256SivAead::generate_key(rand::thread_rng());
         #[cfg(feature = "openssl")]
-        let key = todo!();
+        let key = {
+            //NOTE: call sites for this function don't expect failure, maybe that should be adjusted
+            let mut key_data = Key::<Aes256Siv>::default();
+            let cipher = &openssl::cipher::Cipher::fetch(None, Aes256Siv::name(), None).unwrap();
+            let mut ctx = openssl::cipher_ctx::CipherCtx::new().unwrap();
+            ctx.encrypt_init(Some(cipher), None, None).unwrap();
+            ctx.rand_key(key_data.as_mut()).unwrap();
+
+            key_data
+        };
 
         Self { key }
     }
@@ -294,18 +327,11 @@ impl Cipher for AesSivCmac512 {
         let mut siv = Aes256Siv::new(&self.key);
         let nonce: [u8; 16] = rand::thread_rng().r#gen();
 
-        // Prepare the buffer for in place encryption by moving the plaintext
-        // back, creating space for the nonce.
-        if buffer.len() < nonce.len() + plaintext_length {
-            return Err(std::io::ErrorKind::WriteZero.into());
-        }
-        buffer.copy_within(..plaintext_length, nonce.len());
-        // And place the nonce where the caller expects it
-        buffer[..nonce.len()].copy_from_slice(&nonce);
+        let buffer = prepend_nonce(buffer, plaintext_length, &nonce)?;
 
         // Create a wrapper around the plaintext portion of the buffer that has
         // the methods aes_siv needs to do encryption in-place.
-        let mut buffer_wrap = Buffer::new(&mut buffer[nonce.len()..], plaintext_length);
+        let mut buffer_wrap = Buffer::new(buffer, plaintext_length);
         siv.encrypt_in_place([associated_data, &nonce], &mut buffer_wrap)
             .map_err(|_| std::io::ErrorKind::Other)?;
 
@@ -334,7 +360,21 @@ impl Cipher for AesSivCmac512 {
         plaintext_length: usize,
         associated_data: &[u8],
     ) -> std::io::Result<EncryptResult> {
-        todo!()
+        let nonce: [u8; 16] = rand::thread_rng().r#gen();
+
+        let buffer = prepend_nonce(buffer, plaintext_length, &nonce)?;
+
+        let ciphertext_length = openssl_defs::encrypt_in_place(
+            &self.key,
+            buffer,
+            plaintext_length,
+            [associated_data, nonce.as_slice()],
+        )?;
+
+        Ok(EncryptResult {
+            nonce_length: nonce.len(),
+            ciphertext_length,
+        })
     }
 
     #[cfg(feature = "openssl")]
@@ -344,7 +384,8 @@ impl Cipher for AesSivCmac512 {
         ciphertext: &[u8],
         associated_data: &[u8],
     ) -> Result<Vec<u8>, DecryptError> {
-        todo!()
+        openssl_defs::decrypt_vec(&self.key, ciphertext, [associated_data, nonce])
+            .map_err(|_| DecryptError)
     }
 
     fn key_bytes(&self) -> &[u8] {

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -171,7 +171,7 @@ impl AesSivCmac256 {
         Self::new(GenericArray::default()).key.len()
     }
 
-    pub fn from_key_bytes(key_bytes: &[u8]) -> Result<Self, KeyError> {
+    pub fn try_from(key_bytes: &[u8]) -> Result<Self, KeyError> {
         (key_bytes.len() == Self::key_size())
             .then(|| Self::new(aead::Key::<Aes128Siv>::clone_from_slice(key_bytes)))
             .ok_or(KeyError)
@@ -244,9 +244,18 @@ pub struct AesSivCmac512 {
     key: Key<Aes256Siv>,
 }
 
+use std::borrow::Borrow;
+
 impl AesSivCmac512 {
+    // this is necessary for call sites where we want to use type-driven inference
     pub fn new(key: Key<Aes256Siv>) -> Self {
-        AesSivCmac512 { key }
+        Self { key }
+    }
+
+    pub fn from(bytes: impl IntoIterator<Item: Borrow<u8>>) -> Self {
+        Self {
+            key: bytes.into_iter().map(|x| *x.borrow()).collect(),
+        }
     }
 
     pub fn key_size() -> usize {
@@ -254,14 +263,16 @@ impl AesSivCmac512 {
         Self::new(GenericArray::default()).key.len()
     }
 
-    pub fn from_key_bytes(key_bytes: &[u8]) -> Result<Self, KeyError> {
+    pub fn try_from(key_bytes: &[u8]) -> Result<Self, KeyError> {
         (key_bytes.len() == Self::key_size())
-            .then(|| Self::new(aead::Key::<Aes256Siv>::clone_from_slice(key_bytes)))
+            .then(|| Self::from(key_bytes))
             .ok_or(KeyError)
     }
 
     pub fn new_random() -> Self {
-        Self::new(aes_siv::Aes256SivAead::generate_key(rand::thread_rng()))
+        Self {
+            key: aes_siv::Aes256SivAead::generate_key(rand::thread_rng()),
+        }
     }
 }
 
@@ -490,18 +501,12 @@ mod tests {
         assert_eq!(Aes256Siv::key_size(), AesSivCmac512::key_size());
 
         let key_bytes = (1..=64).collect::<Vec<u8>>();
-        assert!(AesSivCmac256::from_key_bytes(&key_bytes).is_err());
+        assert!(AesSivCmac256::try_from(&key_bytes).is_err());
 
         let slice = &key_bytes[..AesSivCmac256::key_size()];
-        assert_eq!(
-            AesSivCmac256::from_key_bytes(slice).unwrap().key_bytes(),
-            slice
-        );
+        assert_eq!(AesSivCmac256::try_from(slice).unwrap().key_bytes(), slice);
 
         let slice = &key_bytes[..AesSivCmac512::key_size()];
-        assert_eq!(
-            AesSivCmac512::from_key_bytes(slice).unwrap().key_bytes(),
-            slice
-        );
+        assert_eq!(AesSivCmac512::try_from(slice).unwrap().key_bytes(), slice);
     }
 }

--- a/ntp-proto/src/packet/crypto.rs
+++ b/ntp-proto/src/packet/crypto.rs
@@ -162,7 +162,7 @@ impl Drop for AesSivCmac256 {
 /// Prepare the buffer for in place encryption by moving the plaintext
 /// back, creating space for the nonce.
 /// And place the nonce where the caller expects it
-fn prepend_nonce<'a>(
+fn prepend_slice<'a>(
     buffer: &'a mut [u8],
     length: usize,
     nonce: &[u8],
@@ -187,7 +187,7 @@ impl Cipher for AesSivCmac256 {
         let mut siv = Aes128Siv::new(&self.key);
         let nonce: [u8; 16] = rand::thread_rng().r#gen();
 
-        let buffer = prepend_nonce(buffer, plaintext_length, &nonce)?;
+        let buffer = prepend_slice(buffer, plaintext_length, &nonce)?;
 
         // Create a wrapper around the plaintext portion of the buffer that has
         // the methods aes_siv needs to do encryption in-place.
@@ -222,7 +222,7 @@ impl Cipher for AesSivCmac256 {
     ) -> std::io::Result<EncryptResult> {
         let nonce: [u8; 16] = rand::thread_rng().r#gen();
 
-        let buffer = prepend_nonce(buffer, plaintext_length, &nonce)?;
+        let buffer = prepend_slice(buffer, plaintext_length, &nonce)?;
 
         let ciphertext_length = openssl_defs::encrypt_in_place(
             &self.key,
@@ -327,7 +327,7 @@ impl Cipher for AesSivCmac512 {
         let mut siv = Aes256Siv::new(&self.key);
         let nonce: [u8; 16] = rand::thread_rng().r#gen();
 
-        let buffer = prepend_nonce(buffer, plaintext_length, &nonce)?;
+        let buffer = prepend_slice(buffer, plaintext_length, &nonce)?;
 
         // Create a wrapper around the plaintext portion of the buffer that has
         // the methods aes_siv needs to do encryption in-place.
@@ -362,7 +362,7 @@ impl Cipher for AesSivCmac512 {
     ) -> std::io::Result<EncryptResult> {
         let nonce: [u8; 16] = rand::thread_rng().r#gen();
 
-        let buffer = prepend_nonce(buffer, plaintext_length, &nonce)?;
+        let buffer = prepend_slice(buffer, plaintext_length, &nonce)?;
 
         let ciphertext_length = openssl_defs::encrypt_in_place(
             &self.key,

--- a/ntp-proto/src/packet/crypto/buffer.rs
+++ b/ntp-proto/src/packet/crypto/buffer.rs
@@ -1,0 +1,41 @@
+pub struct Buffer<'a> {
+    buffer: &'a mut [u8],
+    valid: usize,
+}
+
+impl<'a> Buffer<'a> {
+    pub fn new(buffer: &'a mut [u8], valid: usize) -> Self {
+        Self { buffer, valid }
+    }
+
+    pub fn valid(&self) -> usize {
+        self.valid
+    }
+}
+
+impl AsMut<[u8]> for Buffer<'_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buffer[..self.valid]
+    }
+}
+
+impl AsRef<[u8]> for Buffer<'_> {
+    fn as_ref(&self) -> &[u8] {
+        &self.buffer[..self.valid]
+    }
+}
+
+impl aead::Buffer for Buffer<'_> {
+    fn extend_from_slice(&mut self, other: &[u8]) -> aead::Result<()> {
+        self.buffer
+            .get_mut(self.valid..(self.valid + other.len()))
+            .ok_or(aead::Error)?
+            .copy_from_slice(other);
+        self.valid += other.len();
+        Ok(())
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.valid = std::cmp::min(self.valid, len);
+    }
+}

--- a/ntp-proto/src/packet/crypto/openssl_defs.rs
+++ b/ntp-proto/src/packet/crypto/openssl_defs.rs
@@ -1,0 +1,67 @@
+//! This file contains file types that mimic those in RustCrypto, so *at a source level* code sharing can be maximized.
+
+use std::ops::Deref;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Aes128Siv;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Aes256Siv;
+
+#[repr(transparent)]
+pub struct Key<T>(<Key<T> as Deref>::Target)
+where
+    Key<T>: Deref;
+
+impl Deref for Key<Aes128Siv> {
+    type Target = [u8; 32];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Deref for Key<Aes256Siv> {
+    type Target = [u8; 64];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Default for Key<Aes128Siv> {
+    fn default() -> Self {
+        Self([0; _])
+    }
+}
+
+impl Default for Key<Aes256Siv> {
+    fn default() -> Self {
+        Self([0; _])
+    }
+}
+
+impl<T> FromIterator<u8> for Key<T>
+where
+    Key<T>: Deref + Default,
+    <Key<T> as Deref>::Target: AsMut<[u8]>,
+{
+    fn from_iter<I: IntoIterator<Item = u8>>(data: I) -> Self {
+        let mut iter = data.into_iter();
+        let mut new = Self::default();
+        for elem in new.as_mut() {
+            *elem = iter.next().expect("input data too short");
+        }
+
+        assert_eq!(iter.count(), 0, "input data too long");
+        new
+    }
+}
+
+impl<T> AsMut<[u8]> for Key<T>
+where
+    Key<T>: Deref,
+    <Key<T> as Deref>::Target: AsMut<[u8]>,
+{
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}

--- a/ntp-proto/src/packet/crypto/openssl_defs.rs
+++ b/ntp-proto/src/packet/crypto/openssl_defs.rs
@@ -148,9 +148,14 @@ where
 
     ctx.encrypt_init(Some(cipher), Some(key.as_ref()), None)?;
 
-    let (tag, ciphertext) = buffer
-        .split_at_mut_checked(ctx.tag_length())
-        .ok_or_else(|| io::Error::from(io::ErrorKind::WriteZero))?;
+    // this is annoying since we're copying a second time; but it does make
+    // the layer above more logical to follow
+    if buffer.len() < plaintext_length + ctx.tag_length() {
+        return Err(std::io::ErrorKind::WriteZero.into());
+    }
+    buffer.copy_within(..plaintext_length, ctx.tag_length());
+
+    let (tag, ciphertext) = buffer.split_at_mut(ctx.tag_length());
 
     for aad_data in aad.into_iter() {
         ctx.cipher_update(aad_data, None)?;

--- a/ntp-proto/src/packet/crypto/openssl_defs.rs
+++ b/ntp-proto/src/packet/crypto/openssl_defs.rs
@@ -82,6 +82,20 @@ where
     }
 }
 
+#[cfg(test)]
+impl From<<Self as Deref>::Target> for Key<Aes128Siv> {
+    fn from(data: <Self as Deref>::Target) -> Self {
+        Self(data)
+    }
+}
+
+#[cfg(test)]
+impl From<<Self as Deref>::Target> for Key<Aes256Siv> {
+    fn from(data: <Self as Deref>::Target) -> Self {
+        Self(data)
+    }
+}
+
 pub trait SSLName {
     fn name() -> &'static str;
 }
@@ -147,4 +161,29 @@ where
     ctx.tag(tag)?;
 
     Ok(ciphertext_length + tag.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_roundtrip() {
+        let payload: [u8; 16] = std::array::from_fn(|i| i as u8);
+        let mut buf = [0; 32];
+        buf[..16].copy_from_slice(&payload);
+        let key: Key<Aes128Siv> = Default::default();
+        let size = encrypt_in_place(&key, &mut buf, 16, [&[1], &[2]]).unwrap();
+        let ciphertext = &buf[..size];
+        let plaintext = decrypt_vec(&key, ciphertext, [&[1], &[2]]).unwrap();
+        assert_eq!(plaintext, payload);
+
+        let mut buf = [0; 32];
+        buf[..16].copy_from_slice(&payload);
+        let key: Key<Aes256Siv> = Default::default();
+        let size = encrypt_in_place(&key, &mut buf, 16, [&[1], &[2]]).unwrap();
+        let ciphertext = &buf[..size];
+        let plaintext = decrypt_vec(&key, ciphertext, [&[1], &[2]]).unwrap();
+        assert_eq!(plaintext, payload);
+    }
 }

--- a/ntp-proto/src/packet/crypto/openssl_defs.rs
+++ b/ntp-proto/src/packet/crypto/openssl_defs.rs
@@ -1,5 +1,6 @@
 //! This file contains file types that mimic those in RustCrypto, so *at a source level* code sharing can be maximized.
 
+use std::io;
 use std::ops::Deref;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -8,10 +9,18 @@ pub struct Aes128Siv;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Aes256Siv;
 
-#[repr(transparent)]
-pub struct Key<T>(<Key<T> as Deref>::Target)
-where
-    Key<T>: Deref;
+impl SSLName for Aes128Siv {
+    // NOTE: the argument is used to prevent coding mistakes at compile time
+    fn name() -> &'static str {
+        "AES-128-SIV"
+    }
+}
+
+impl SSLName for Aes256Siv {
+    fn name() -> &'static str {
+        "AES-256-SIV"
+    }
+}
 
 impl Deref for Key<Aes128Siv> {
     type Target = [u8; 32];
@@ -27,6 +36,8 @@ impl Deref for Key<Aes256Siv> {
     }
 }
 
+// The following is boilerplate or generic code
+
 impl Default for Key<Aes128Siv> {
     fn default() -> Self {
         Self([0; _])
@@ -38,6 +49,11 @@ impl Default for Key<Aes256Siv> {
         Self([0; _])
     }
 }
+
+#[repr(transparent)]
+pub struct Key<T>(<Key<T> as Deref>::Target)
+where
+    Key<T>: Deref;
 
 impl<T> FromIterator<u8> for Key<T>
 where
@@ -64,4 +80,71 @@ where
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.as_mut()
     }
+}
+
+pub trait SSLName {
+    fn name() -> &'static str;
+}
+
+// NOTE for future modifications: if AES-GCM-SIV is to be added, keep in mind lessons learned the hard way:
+// - the tag is at the end of the ciphertext, whereas with AES-SIV it sits at the beginning
+// - the nonce needs to be set using crypt_init as the IV and is not provided as associated data
+
+pub fn decrypt_vec<T: SSLName>(
+    key: &Key<T>,
+    ciphertext: &[u8],
+    aad: [&[u8]; 2],
+) -> io::Result<Vec<u8>>
+where
+    Key<T>: Deref,
+    <Key<T> as Deref>::Target: AsRef<[u8]>,
+{
+    let cipher = &openssl::cipher::Cipher::fetch(None, T::name(), None)?;
+    let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
+
+    ctx.decrypt_init(Some(cipher), Some(key.as_ref()), None)?;
+
+    let (tag, ciphertext) = ciphertext
+        .split_at_checked(ctx.tag_length())
+        .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
+
+    let mut output = Vec::new();
+    ctx.set_tag(tag)?;
+    for aad_data in aad.into_iter() {
+        ctx.cipher_update(aad_data, None)?;
+    }
+    ctx.cipher_update_vec(ciphertext, &mut output)?;
+    ctx.cipher_final_vec(&mut output)?;
+
+    Ok(output)
+}
+
+pub fn encrypt_in_place<T: SSLName>(
+    key: &Key<T>,
+    buffer: &mut [u8],
+    plaintext_length: usize,
+    aad: [&[u8]; 2],
+) -> io::Result<usize>
+where
+    Key<T>: Deref,
+    <Key<T> as Deref>::Target: AsRef<[u8]>,
+{
+    let cipher = &openssl::cipher::Cipher::fetch(None, T::name(), None)?;
+    let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
+
+    ctx.encrypt_init(Some(cipher), Some(key.as_ref()), None)?;
+
+    let (tag, ciphertext) = buffer
+        .split_at_mut_checked(ctx.tag_length())
+        .ok_or_else(|| io::Error::from(io::ErrorKind::WriteZero))?;
+
+    for aad_data in aad.into_iter() {
+        ctx.cipher_update(aad_data, None)?;
+    }
+    let mut ciphertext_length = ctx.cipher_update_inplace(ciphertext, plaintext_length)?;
+    ciphertext_length += ctx.cipher_final(&mut ciphertext[ciphertext_length..])?;
+
+    ctx.tag(tag)?;
+
+    Ok(ciphertext_length + tag.len())
 }

--- a/ntp-proto/src/packet/crypto/openssl_defs.rs
+++ b/ntp-proto/src/packet/crypto/openssl_defs.rs
@@ -9,56 +9,48 @@ pub struct Aes128Siv;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Aes256Siv;
 
-impl SSLName for Aes128Siv {
-    // NOTE: the argument is used to prevent coding mistakes at compile time
+pub trait EVPCipher {
+    type Key: AsRef<[u8]> + AsMut<[u8]>;
+    fn name() -> &'static str;
+}
+
+impl EVPCipher for Aes128Siv {
+    type Key = [u8; 32];
+
     fn name() -> &'static str {
         "AES-128-SIV"
     }
 }
 
-impl SSLName for Aes256Siv {
+impl EVPCipher for Aes256Siv {
+    type Key = [u8; 64];
+
     fn name() -> &'static str {
         "AES-256-SIV"
     }
 }
 
-impl Deref for Key<Aes128Siv> {
-    type Target = [u8; 32];
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Deref for Key<Aes256Siv> {
-    type Target = [u8; 64];
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+#[repr(transparent)]
+pub struct Key<T: EVPCipher>(T::Key);
 
 // The following is boilerplate or generic code
 
-impl Default for Key<Aes128Siv> {
+impl<T: EVPCipher> Deref for Key<T> {
+    type Target = T::Key;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const N: usize, T: EVPCipher<Key = [u8; N]>> Default for Key<T> {
     fn default() -> Self {
         Self([0; _])
     }
 }
 
-impl Default for Key<Aes256Siv> {
-    fn default() -> Self {
-        Self([0; _])
-    }
-}
-
-#[repr(transparent)]
-pub struct Key<T>(<Key<T> as Deref>::Target)
+impl<T: EVPCipher> FromIterator<u8> for Key<T>
 where
-    Key<T>: Deref;
-
-impl<T> FromIterator<u8> for Key<T>
-where
-    Key<T>: Deref + Default,
-    <Key<T> as Deref>::Target: AsMut<[u8]>,
+    Self: Default,
 {
     fn from_iter<I: IntoIterator<Item = u8>>(data: I) -> Self {
         let mut iter = data.into_iter();
@@ -72,46 +64,29 @@ where
     }
 }
 
-impl<T> AsMut<[u8]> for Key<T>
-where
-    Key<T>: Deref,
-    <Key<T> as Deref>::Target: AsMut<[u8]>,
-{
+impl<T: EVPCipher> AsMut<[u8]> for Key<T> {
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.as_mut()
     }
 }
 
 #[cfg(test)]
-impl From<<Self as Deref>::Target> for Key<Aes128Siv> {
-    fn from(data: <Self as Deref>::Target) -> Self {
+impl<const N: usize, T: EVPCipher<Key = [u8; N]>> From<[u8; N]> for Key<T> {
+    fn from(data: [u8; N]) -> Self {
         Self(data)
     }
-}
-
-#[cfg(test)]
-impl From<<Self as Deref>::Target> for Key<Aes256Siv> {
-    fn from(data: <Self as Deref>::Target) -> Self {
-        Self(data)
-    }
-}
-
-pub trait SSLName {
-    fn name() -> &'static str;
 }
 
 // NOTE for future modifications: if AES-GCM-SIV is to be added, keep in mind lessons learned the hard way:
 // - the tag is at the end of the ciphertext, whereas with AES-SIV it sits at the beginning
 // - the nonce needs to be set using crypt_init as the IV and is not provided as associated data
 
-pub fn decrypt_vec<T: SSLName>(
+pub fn decrypt_vec<T: EVPCipher>(
     key: &Key<T>,
     ciphertext: &[u8],
     aad: [&[u8]; 2],
 ) -> io::Result<Vec<u8>>
 where
-    Key<T>: Deref,
-    <Key<T> as Deref>::Target: AsRef<[u8]>,
 {
     let cipher = &openssl::cipher::Cipher::fetch(None, T::name(), None)?;
     let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
@@ -133,15 +108,13 @@ where
     Ok(output)
 }
 
-pub fn encrypt_in_place<T: SSLName>(
+pub fn encrypt_in_place<T: EVPCipher>(
     key: &Key<T>,
     buffer: &mut [u8],
     plaintext_length: usize,
     aad: [&[u8]; 2],
 ) -> io::Result<usize>
 where
-    Key<T>: Deref,
-    <Key<T> as Deref>::Target: AsRef<[u8]>,
 {
     let cipher = &openssl::cipher::Cipher::fetch(None, T::name(), None)?;
     let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;

--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -35,11 +35,6 @@ rustls-openssl = { workspace = true, optional = true }
 ntp-proto = { workspace = true, features = ["__internal-test",] }
 tokio-rustls.workspace = true
 
-[target.'cfg(target_env = "musl")'.dependencies.rustls-openssl]
-workspace = true
-optional = true
-features = ["vendored"]
-
 [features]
 default = [ "aws-lc", "rustcrypto", "pps", "srv" ]
 hardware-timestamping = []
@@ -48,6 +43,7 @@ srv = [ "dep:hickory-resolver" ]
 aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
 rustcrypto = ["ntp-proto/rustcrypto"]
 openssl = ["dep:rustls-openssl", "ntp-proto/openssl"]
+openssl-vendored = ["openssl", "rustls-openssl/vendored"]
 
 [package.metadata.deb]
 name = "ntpd-rs"

--- a/ntpd/Cargo.toml
+++ b/ntpd/Cargo.toml
@@ -41,12 +41,13 @@ optional = true
 features = ["vendored"]
 
 [features]
-default = [ "aws-lc", "pps", "srv" ]
+default = [ "aws-lc", "rustcrypto", "pps", "srv" ]
 hardware-timestamping = []
 pps = [ "dep:pps-time" ]
 srv = [ "dep:hickory-resolver" ]
 aws-lc = ["rustls23/aws-lc-rs", "rustls23/prefer-post-quantum"] # the latter also turns on aws-lc-rs
-openssl = ["dep:rustls-openssl"]
+rustcrypto = ["ntp-proto/rustcrypto"]
+openssl = ["dep:rustls-openssl", "ntp-proto/openssl"]
 
 [package.metadata.deb]
 name = "ntpd-rs"


### PR DESCRIPTION
Notes:

- MD5 in OpenSSL can return an error (!?); I've made this into an unwrap since any error handling would also result in ntpd-rs exiting.

- First other few commits decouple some of the RustCrypto details from `packet/crypto.rs`

- `crypto/openssl_defs.rs` contains some helper definitions that will allow a lot of source-level code sharing between the Rustcrypto and OpenSSL side by mimicking some types. I do not use `GenericArray` here because I don't like that particular construction. Sadly Rust doesn't allow sizes of types to depend on trait constants but I found a way around that.