### PR TITLE
Add newline before markdown list

### DIFF
--- a/docs/development/code-structure.md
+++ b/docs/development/code-structure.md
@@ -21,6 +21,7 @@ which are purposefully kept small and only offer a safe API.
 
 The `ntp-proto` crate contains the main NTP protocol implementation. It
 implements:
+
  - Serialization and deserialization of the on-wire protocol.
  - Packet handling decision logic of the source.
  - Measurement logic of the source, including the per-source filtering.
@@ -73,6 +74,7 @@ Immediately after, further configuration is read from file and used to generate
 the definitive logging system. At this point, the main configuration steps are
 completed, and the combined command line and file base configuration is used to
 set up at least these kinds of tasks:
+
  - The main clock steering task.
  - One source task per configured source (remote server).
  - One server task per configured interface on which to serve time.
@@ -87,6 +89,7 @@ sending the poll message to start a clock difference measurement, handling the
 response, and doing an initial filtering step over the measurements.
 
 The main loop of the source waits on 3 futures concurrently:
+
  - A timer, which triggers sending a new poll message.
  - The network socket, receiving a packet here triggers packet processing and
    measurement filtering.
@@ -104,6 +107,7 @@ responsible for managing the socket for that interface, reading messages and
 providing the proper server responses.
 
 The main loop of the server waits on 2 futures concurrently:
+
  - The network socket
  - A channel providing synchronization state updates
 

--- a/docs/guide/ntpv5.md
+++ b/docs/guide/ntpv5.md
@@ -12,7 +12,7 @@ differences:
   only supports these modes).
 - Fields in the NTP server and client messages have been defined more clearly.
 - NTPv5 has a better mechanism for handling loop detection.
-- Several other minor improvments and changes.
+- Several other minor improvements and changes.
 
 All of this taken together, we believe that NTPv5 is a significant improvement
 over NTPv4. Because of this, you can already use ntpd-rs as an NTPv5 client or

--- a/docs/guide/security-guidance.md
+++ b/docs/guide/security-guidance.md
@@ -78,6 +78,7 @@ The clock steering is based on the ntpd-rs configuration file. If an attacker ca
 Similarly, for logs it is recommended to restrict who can read the logs. It is also strongly advisable to configure log rotation and limits on the maximum size of the log through the systems logging facilities, to prevent logs from accidentally becoming so large as to impede normal system operation. When configured with a `log-level` of info or higher, the daemon should not log in direct response to random network traffic. However, log output is proportional to the number of remote time sources configured.
 
 Furthermore, the ntpd-rs daemon can be configured to expose two sockets:
+
 - The observe socket is read-only and exposes some of the source and clock
   algorithm state.
 - The configuration socket accepts commands and allows changing of some of the


### PR DESCRIPTION
Some of the markdown lists in the documentation don't have a preceding newline, causing them to be rendered inline, when this is likely not intended. See [this section on ntp-proto](https://docs.ntpd-rs.pendulum-project.org/development/code-structure/#ntp-proto) for example:

<img width="619" height="133" alt="image" src="https://github.com/user-attachments/assets/d45be34f-87e8-4d67-957e-ffad4a2c0115" />
