### PR TITLE
Fix broken code-of-conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 We abide by the [Rust Code of Conduct][coc] and ask that you do as well.
 
-[coc]: https://www.rust-lang.org/en-US/conduct.html
+[coc]: https://www.rust-lang.org/policies/code-of-conduct/


### PR DESCRIPTION
The current link in the [Code of Conduct](https://github.com/pendulum-project/ntpd-rs/blob/29e63944f39b2d1457381c4d2ee4be7ccafa4f88/CODE_OF_CONDUCT.md) returns a 404. 

The new working URL is https://www.rust-lang.org/policies/code-of-conduct/