### PR TITLE
Update timestamped-socket to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1725,9 +1725,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "timestamped-socket"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f968af71a51b915706b71490d332a64de3981c3487be10c7531c1ac3d493316"
+checksum = "72ed4c1aa229f1b2b469b9ae0d4eecd921e2d7430653a4f6d49b166c84a96d25"
 dependencies = [
  "libc",
  "serde",
@@ -2098,7 +2098,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/pendulum-project/ntpd-rs"
 readme = "./README.md"
 description = "Full-featured implementation of NTP with NTS support"
 publish = true
-rust-version = "1.88" # MSRV
+rust-version = "1.95" # MSRV
 
 # Because of the async runtime, we really want panics to cause an abort, otherwise
 # the binary can keep on running as a ghost
@@ -39,7 +39,7 @@ pps-time = "0.2.3"
 rand = "0.8.0"
 serde = { version = "1.0.166", features = ["derive"] }
 serde_json = "1.0"
-timestamped-socket = "0.2.2"
+timestamped-socket = "0.3.0"
 tokio = "1.37"
 toml = { version = ">=0.6.0,<0.9.0", default-features = false, features = ["parse"] }
 tracing = "0.1.37"

--- a/ntpd/src/daemon/ntp_source.rs
+++ b/ntpd/src/daemon/ntp_source.rs
@@ -233,6 +233,7 @@ where
                             Ok(opt_send_timestamp) => {
                                 // update the last_send_timestamp with the one given by the kernel, if available
                                 self.last_send_timestamp = opt_send_timestamp
+                                    .selected_timestamp()
                                     .map(convert_net_timestamp)
                                     .or(self.last_send_timestamp);
                             }
@@ -351,10 +352,10 @@ fn accept_packet<'a, C: NtpClock>(
     match result {
         Ok(RecvResult {
             bytes_read: size,
-            timestamp,
+            timestamp_data,
             ..
         }) => {
-            let recv_timestamp = timestamp.map_or_else(
+            let recv_timestamp = timestamp_data.selected_timestamp().map_or_else(
                 || match clock.now() {
                     Ok(now) => {
                         debug!(?size, "received a packet without a timestamp, substituting");
@@ -541,6 +542,7 @@ mod tests {
         let test_socket = open_ip(
             SocketAddr::from((Ipv4Addr::LOCALHOST, port_base)),
             GeneralTimestampMode::SoftwareRecv,
+            false,
         )
         .unwrap();
 
@@ -641,11 +643,12 @@ mod tests {
         let mut buf = [0; 48];
         let RecvResult {
             bytes_read: size,
-            timestamp,
+            timestamp_data,
             remote_addr,
+            ..
         } = socket.recv(&mut buf).await.unwrap();
         assert_eq!(size, 48);
-        let timestamp = timestamp.unwrap();
+        let timestamp = timestamp_data.selected_timestamp().unwrap();
 
         let rec_packet = NtpPacket::deserialize(&buf, &NoCipher).unwrap().0;
         let send_packet = NtpPacket::timestamp_response(
@@ -681,11 +684,12 @@ mod tests {
             let mut buf = [0; 48];
             let RecvResult {
                 bytes_read: size,
-                timestamp,
+                timestamp_data,
                 remote_addr,
+                ..
             } = socket.recv(&mut buf).await.unwrap();
             assert_eq!(size, 48);
-            assert!(timestamp.is_some());
+            assert!(timestamp_data.selected_timestamp().is_some());
 
             let rec_packet = NtpPacket::deserialize(&buf, &NoCipher).unwrap().0;
             let send_packet = NtpPacket::deny_response(rec_packet);

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -168,23 +168,37 @@ impl<C: 'static + NtpClock + Send> ServerTask<C> {
                         Ok(RecvResult {
                             bytes_read: length,
                             remote_addr: source_addr,
+                            local_addr,
                             timestamp_data,
                             ..
                         }) if let Some(timestamp) = timestamp_data.selected_timestamp() => {
                             let mut send_buf = [0u8; MAX_PACKET_SIZE];
-                            match self.server.handle(source_addr.ip(), convert_net_timestamp(timestamp), &buf[..length], &mut send_buf[..length], &mut self.stats) {
-                                ntp_proto::ServerAction::Ignore => { /* explicitly do nothing */ },
+                            match self.server.handle(
+                                source_addr.ip(),
+                                convert_net_timestamp(timestamp),
+                                &buf[..length],
+                                &mut send_buf[..length],
+                                &mut self.stats,
+                            ) {
+                                ntp_proto::ServerAction::Ignore => { /* explicitly do nothing */ }
                                 ntp_proto::ServerAction::Respond { message } => {
-                                    if let Err(send_err) = socket.send_to(message, source_addr).await {
+                                    if let Err(send_err) =
+                                        socket.send_from_to(message, local_addr, source_addr).await
+                                    {
                                         self.stats.response_send_errors.inc();
                                         debug!(error=?send_err, "Could not send response packet");
                                     }
-                                },
+                                }
                             }
                         }
                         Ok(_) => {
                             debug!("received a packet without a timestamp");
-                            self.stats.register(0, false, ServerReason::InternalError, ServerResponse::Ignore);
+                            self.stats.register(
+                                0,
+                                false,
+                                ServerReason::InternalError,
+                                ServerResponse::Ignore,
+                            );
                         }
                         Err(receive_error) => {
                             warn!(?receive_error, "could not receive packet");

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -142,6 +142,7 @@ impl<C: 'static + NtpClock + Send> ServerTask<C> {
                     let socket_res = open_ip(
                         self.config.listen,
                         timestamped_socket::socket::GeneralTimestampMode::SoftwareRecv,
+                        false,
                     );
 
                     match socket_res {
@@ -167,8 +168,9 @@ impl<C: 'static + NtpClock + Send> ServerTask<C> {
                         Ok(RecvResult {
                             bytes_read: length,
                             remote_addr: source_addr,
-                            timestamp: Some(timestamp),
-                        }) => {
+                            timestamp_data,
+                            ..
+                        }) if let Some(timestamp) = timestamp_data.selected_timestamp() => {
                             let mut send_buf = [0u8; MAX_PACKET_SIZE];
                             match self.server.handle(source_addr.ip(), convert_net_timestamp(timestamp), &buf[..length], &mut send_buf[..length], &mut self.stats) {
                                 ntp_proto::ServerAction::Ignore => { /* explicitly do nothing */ },
@@ -304,6 +306,7 @@ mod tests {
         let socket = open_ip(
             SocketAddr::new("127.0.0.1".parse().unwrap(), alloc_port()),
             GeneralTimestampMode::SoftwareRecv,
+            false,
         )
         .unwrap();
         let mut socket = socket


### PR DESCRIPTION
This updates timestamped socket to the new API, which is needed for #2210 as well as the solution to #1880. In draft until we publish a definitive version of timestamped-socket 0.3.0