### PR TITLE
Add clippy::cast_lossless

### DIFF
--- a/ntpd/src/daemon/clock.rs
+++ b/ntpd/src/daemon/clock.rs
@@ -40,11 +40,10 @@ impl NtpClock for NtpClockWrapper {
         offset: ntp_proto::NtpDuration,
     ) -> Result<ntp_proto::NtpTimestamp, Self::Error> {
         let (seconds, nanos) = offset.as_seconds_nanos();
+        #[cfg(not(target_pointer_width = "32"))]
+        let seconds = seconds.into();
         self.0
-            .step_clock(TimeOffset {
-                seconds: seconds as _,
-                nanos,
-            })
+            .step_clock(TimeOffset { seconds, nanos })
             .map(convert_clock_timestamp)
     }
 

--- a/ntpd/src/daemon/clock.rs
+++ b/ntpd/src/daemon/clock.rs
@@ -40,7 +40,7 @@ impl NtpClock for NtpClockWrapper {
         offset: ntp_proto::NtpDuration,
     ) -> Result<ntp_proto::NtpTimestamp, Self::Error> {
         let (seconds, nanos) = offset.as_seconds_nanos();
-        #[cfg(not(target_pointer_width = "32"))]
+        #[allow(clippy::useless_conversion)]
         let seconds = seconds.into();
         self.0
             .step_clock(TimeOffset { seconds, nanos })

--- a/ntpd/src/lib.rs
+++ b/ntpd/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(clippy::bool_to_int_with_if)]
 #![warn(clippy::borrow_as_ptr)]
 #![warn(clippy::case_sensitive_file_extension_comparisons)]
-//FIXME: Enable #![warn(clippy::cast_lossless)]
+#![warn(clippy::cast_lossless)]
 //FIXME: Enable #![warn(clippy::cast_possible_truncation)]
 #![warn(clippy::cast_possible_wrap)]
 //FIXME: Enable #![warn(clippy::cast_precision_loss)]


### PR DESCRIPTION
The `clippy::cast_lossless` lint was originally included in #2330, but deserves a more thorough look. The lint suggests the following to convert an i32 to an i64:

```diff
self.0
    .step_clock(TimeOffset {
-        seconds: seconds as _,
+        seconds: seconds.into(),
        nanos,
    })
```

However, on 32 bit systems, the `seconds` are also an i32 and thus clippy complains that the call to `.into()` is a noop. I propose gating the `into()` call behind a `target_arch` feature.

Edit: `target_arch` still caused issues in CI, so I switched to `target_pointer_width`