### PR TITLE
Fix deamon typo everywhere

### DIFF
--- a/docs/man/ntp-daemon.8.md
+++ b/docs/man/ntp-daemon.8.md
@@ -15,7 +15,7 @@ title: NTP-DAEMON(8) ntpd-rs 1.9.0 | ntpd-rs
 # DESCRIPTION
 
 `ntp-daemon` is the Network Time Protocol (NTP) service daemon for ntpd-rs, an
-NTP implementation with a focus on security and stability. The `ntp-deamon` can
+NTP implementation with a focus on security and stability. The `ntp-daemon` can
 be configured as both an NTP client and an NTP server. The daemon also works
 with the Network Time Security (NTS) protocol. Details of the configuration
 of the daemon and implementation details can be found in ntp.toml(5), where

--- a/docs/man/ntp.toml.5.md
+++ b/docs/man/ntp.toml.5.md
@@ -246,7 +246,7 @@ ntp-metrics-exporter(8).
     daemon. Levels higher than the given log level are logged as well.
 
 `log-path` = *path* (**unset**)
-:   Path to which the deamon should direct its log output. The file at this
+:   Path to which the daemon should direct its log output. The file at this
     location is reopened on SIGHUP. When not present, log output will be
     directed to stdout.
 

--- a/docs/precompiled/man/ntp-daemon.8
+++ b/docs/precompiled/man/ntp-daemon.8
@@ -36,7 +36,7 @@
 \f[V]ntp-daemon\f[R] is the Network Time Protocol (NTP) service daemon
 for ntpd-rs, an NTP implementation with a focus on security and
 stability.
-The \f[V]ntp-deamon\f[R] can be configured as both an NTP client and an
+The \f[V]ntp-daemon\f[R] can be configured as both an NTP client and an
 NTP server.
 The daemon also works with the Network Time Security (NTS) protocol.
 Details of the configuration of the daemon and implementation details

--- a/docs/precompiled/man/ntp.toml.5
+++ b/docs/precompiled/man/ntp.toml.5
@@ -324,7 +324,7 @@ anything going on in the daemon, whereas the highest level
 Levels higher than the given log level are logged as well.
 .TP
 \f[V]log-path\f[R] = \f[I]path\f[R] (\f[B]unset\f[R])
-Path to which the deamon should direct its log output.
+Path to which the daemon should direct its log output.
 The file at this location is reopened on SIGHUP.
 When not present, log output will be directed to stdout.
 .TP

--- a/pkg/test-scripts/test-ntpd-rs.sh
+++ b/pkg/test-scripts/test-ntpd-rs.sh
@@ -9,7 +9,7 @@ case $1 in
       id ntpd-rs
       id ntpd-rs-observe
 
-      # Ensure deamon and ctl client are present
+      # Ensure daemon and ctl client are present
       # and configuration validates.
       echo -e "\nNTPD-RS HELP OUTPUT:"
       /usr/bin/ntp-daemon --help


### PR DESCRIPTION
Flagged by lintian while working on packaging for Ubuntu. Fixed with `rg -l deamon | xargs sed -i 's/deamon/daemon/'`.