### PR TITLE
misaddress #1913 by basically including "chgrp 123" & "chmod g+w" in sock_sources...

### DIFF
--- a/docs/examples/conf/ntpd-rs.service
+++ b/docs/examples/conf/ntpd-rs.service
@@ -13,6 +13,7 @@ Environment="RUST_LOG=info"
 RuntimeDirectory=ntpd-rs
 User=ntpd-rs
 Group=ntpd-rs
+SupplementaryGroups=123
 AmbientCapabilities=CAP_SYS_TIME CAP_NET_BIND_SERVICE
 
 [Install]

--- a/ntpd/src/daemon/sock_source.rs
+++ b/ntpd/src/daemon/sock_source.rs
@@ -1,3 +1,4 @@
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::{fmt::Display, path::Path};
 
@@ -95,6 +96,10 @@ fn create_socket<T: AsRef<Path>>(path: T) -> std::io::Result<UnixDatagram> {
     }
     debug!("Creating socket at {:?}", path);
     let socket = UnixDatagram::bind(path)?;
+    std::os::unix::fs::chown(path, None, Some(123))?;
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_mode(permissions.mode() | 0o020);
+    std::fs::set_permissions(path, permissions)?;
     Ok(socket)
 }
 


### PR DESCRIPTION
This is the toy model.

I expect/welcome constructive critique/pushback.

I think it needs to be configurable.

I wonder which of the following is least objectionable.

```toml
[[source]]
mode = "sock"
path = "/tmp/chrony.ttyS0.sock"
precision = 1e-3
template_from = "/etc/ntpd-rs/sock"

[[source]]
mode = "sock"
path = "/tmp/chrony.ttyS1.sock"
precision = 1e-3
group= 123
mode = 0o620 

[[source]]
mode = "sock"
path = "/tmp/chrony.ttyS2.sock"
precision = 1e-3
group = 123
mode_set = 0o020
model_clear = 0o200
```

Performing group ID lookups by name without shunting into C seems problematic, so I won't.