### PR TITLE
Allow running without updating system clock (issue 2322)

### DIFF
--- a/ntp.toml
+++ b/ntp.toml
@@ -24,3 +24,7 @@ single-step-panic-threshold = 1800
 startup-step-panic-threshold = { forward="inf", backward = 1800 }
 #accumulated-step-panic-threshold = 1800
 #minimum-agreeing-sources = 3
+
+# Set to false to run without CAP_SYS_TIME.
+# The daemon tracks offset internally and serves corrected time to clients.
+#update-system-clock = true

--- a/ntpd/src/ctl.rs
+++ b/ntpd/src/ctl.rs
@@ -406,6 +406,8 @@ mod tests {
             system: SystemSnapshot::default(),
             sources: vec![],
             servers: vec![],
+            system_clock_adjustment: true,
+            accumulated_offset_ms: None,
         };
         let result = write_socket_helper(Format::Plain, value).await?;
 
@@ -424,6 +426,8 @@ mod tests {
             system: SystemSnapshot::default(),
             sources: vec![],
             servers: vec![],
+            system_clock_adjustment: true,
+            accumulated_offset_ms: None,
         };
         let result = write_socket_helper(Format::Prometheus, value).await?;
 

--- a/ntpd/src/daemon/clock.rs
+++ b/ntpd/src/daemon/clock.rs
@@ -1,5 +1,8 @@
 use clock_steering::{Clock, TimeOffset, unix::UnixClock};
 use ntp_proto::NtpClock;
+use ntp_proto::{NtpDuration, NtpTimestamp};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use super::util::convert_clock_timestamp;
 
@@ -72,4 +75,141 @@ impl NtpClock for NtpClockWrapper {
             }
         })
     }
+}
+
+/// Trait for clocks that can convert a system timestamp to "true" time.
+/// For regular clocks this is a no-op; for soft-clock mode it adds the
+/// tracked offset.
+pub trait TrueTimeClock: NtpClock {
+    fn to_true_time(&self, system_time: NtpTimestamp) -> NtpTimestamp;
+}
+
+impl TrueTimeClock for NtpClockWrapper {
+    fn to_true_time(&self, system_time: NtpTimestamp) -> NtpTimestamp {
+        system_time
+    }
+}
+
+/// Clock wrapper that optionally tracks offset without steering the OS.
+/// When `update_system_clock` is false, all steering calls become no-ops
+/// and the offset is tracked internally. `now()` always returns system
+/// time (needed by the Kalman filter and sources); use `to_true_time()`
+/// to convert a system timestamp to the estimated true time.
+#[derive(Clone)]
+pub struct SoftClock<C: NtpClock + Clone> {
+    inner: C,
+    enabled: Arc<AtomicBool>,
+    state: Arc<Mutex<SoftClockState>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SoftClockState {
+    offset: NtpDuration,
+    frequency_ppm: f64,
+    last_update: NtpTimestamp,
+}
+
+impl<C: NtpClock + Clone> SoftClock<C> {
+    pub fn new(inner: C, update_system_clock: bool) -> Self {
+        Self {
+            inner,
+            enabled: Arc::new(AtomicBool::new(update_system_clock)),
+            state: Arc::new(Mutex::new(SoftClockState {
+                offset: NtpDuration::ZERO,
+                frequency_ppm: 0.0,
+                last_update: NtpTimestamp::default(),
+            })),
+        }
+    }
+
+    fn now_true_from_system(&self, sys_ts: NtpTimestamp) -> NtpTimestamp {
+        let state = self.state.lock().unwrap();
+        let elapsed = sys_ts - state.last_update;
+        let elapsed_secs = duration_to_seconds(elapsed);
+        let drift = NtpDuration::from_seconds(elapsed_secs * state.frequency_ppm * 1e-6);
+        sys_ts + state.offset + drift
+    }
+}
+
+impl<C: NtpClock + Clone> NtpClock for SoftClock<C> {
+    type Error = C::Error;
+
+    /// Always returns system time. The Kalman filter and source tasks
+    /// need system time for consistent offset calculations.
+    fn now(&self) -> Result<NtpTimestamp, Self::Error> {
+        self.inner.now()
+    }
+
+    fn set_frequency(&self, freq: f64) -> Result<NtpTimestamp, Self::Error> {
+        if self.enabled.load(Ordering::Relaxed) {
+            self.inner.set_frequency(freq)
+        } else {
+            let mut state = self.state.lock().unwrap();
+            state.frequency_ppm = freq;
+            state.last_update = self.inner.now()?;
+            Ok(state.last_update)
+        }
+    }
+
+    fn get_frequency(&self) -> Result<f64, Self::Error> {
+        if self.enabled.load(Ordering::Relaxed) {
+            self.inner.get_frequency()
+        } else {
+            Ok(self.state.lock().unwrap().frequency_ppm)
+        }
+    }
+
+    fn step_clock(&self, offset: NtpDuration) -> Result<NtpTimestamp, Self::Error> {
+        if self.enabled.load(Ordering::Relaxed) {
+            self.inner.step_clock(offset)
+        } else {
+            let mut state = self.state.lock().unwrap();
+            state.offset = offset;
+            state.last_update = self.inner.now()?;
+            Ok(state.last_update)
+        }
+    }
+
+    fn disable_ntp_algorithm(&self) -> Result<(), Self::Error> {
+        if self.enabled.load(Ordering::Relaxed) {
+            self.inner.disable_ntp_algorithm()
+        } else {
+            Ok(())
+        }
+    }
+
+    fn error_estimate_update(
+        &self,
+        _est_error: NtpDuration,
+        _max_error: NtpDuration,
+    ) -> Result<(), Self::Error> {
+        if self.enabled.load(Ordering::Relaxed) {
+            self.inner.error_estimate_update(_est_error, _max_error)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn status_update(&self, leap_status: ntp_proto::NtpLeapIndicator) -> Result<(), Self::Error> {
+        if self.enabled.load(Ordering::Relaxed) {
+            self.inner.status_update(leap_status)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<C: NtpClock + Clone> TrueTimeClock for SoftClock<C> {
+    fn to_true_time(&self, system_time: NtpTimestamp) -> NtpTimestamp {
+        if self.enabled.load(Ordering::Relaxed) {
+            system_time
+        } else {
+            self.now_true_from_system(system_time)
+        }
+    }
+}
+
+fn duration_to_seconds(d: NtpDuration) -> f64 {
+    let (secs, nanos) = d.as_seconds_nanos();
+    secs as f64 + nanos as f64 / 1_000_000_000.0
 }

--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -385,6 +385,10 @@ fn default_metrics_exporter_listen() -> SocketAddr {
     "127.0.0.1:9975".parse().unwrap()
 }
 
+
+fn default_update_system_clock() -> bool {
+    true
+}
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct DaemonSynchronizationConfig {
@@ -393,6 +397,9 @@ pub struct DaemonSynchronizationConfig {
 
     #[serde(default)]
     pub algorithm: AlgorithmConfig,
+
+    #[serde(default = "default_update_system_clock", rename = "update-system-clock")]
+    pub update_system_clock: bool,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -517,6 +524,14 @@ impl Config {
             info!("No sources configured. Daemon will not change system time.");
         }
 
+
+        if !self.synchronization.update_system_clock {
+            warn!(
+                "update-system-clock is disabled. The daemon will not adjust the OS clock. \
+                 Ensure [[server]] blocks are configured if you intend to serve time, \
+                 otherwise this instance will only monitor without acting."
+            );
+        }
         if !self.sources.is_empty()
             && self.count_sources()
                 < self

--- a/ntpd/src/daemon/mod.rs
+++ b/ntpd/src/daemon/mod.rs
@@ -24,6 +24,7 @@ use std::{error::Error, io::IsTerminal, path::Path};
 
 use ::tracing::info;
 pub use config::Config;
+use self::clock::{NtpClockWrapper, SoftClock};
 use ntp_proto::{KalmanClockController, TimeSyncControllerWrapper};
 pub use observer::ObservableState;
 pub use system::spawn;
@@ -155,13 +156,15 @@ fn run(options: &NtpDaemonOptions) -> Result<(), Box<dyn Error>> {
         let clock_config = config::ClockConfig::default();
 
         ::tracing::debug!("Configuration loaded, spawning daemon jobs");
-        let clock = clock_config.clock;
+        let clock = SoftClock::new(clock_config.clock, config.synchronization.update_system_clock);
         let (main_loop_handle, channels) =
-            spawn::<TimeSyncControllerWrapper<KalmanClockController<_>>>(
+            spawn::<SoftClock<NtpClockWrapper>, TimeSyncControllerWrapper<KalmanClockController<SoftClock<NtpClockWrapper>>>>(
                 config.synchronization.synchronization_base,
                 config.synchronization.algorithm,
                 config.source_defaults,
-                clock_config,
+                clock.clone(),
+                clock_config.interface,
+                clock_config.timestamp_mode,
                 &config.sources,
                 &config.servers,
                 #[cfg(target_os = "linux")]
@@ -182,6 +185,7 @@ fn run(options: &NtpDaemonOptions) -> Result<(), Box<dyn Error>> {
             channels.server_data_receiver,
             channels.system_snapshot_receiver,
             clock,
+            config.synchronization.update_system_clock,
         );
 
         let _ = notify_ready().await;

--- a/ntpd/src/daemon/observer.rs
+++ b/ntpd/src/daemon/observer.rs
@@ -19,6 +19,8 @@ pub struct ObservableState {
     pub system: SystemSnapshot,
     pub sources: Vec<ObservableSourceState>,
     pub servers: Vec<ObservableServerState>,
+    pub system_clock_adjustment: bool,
+    pub accumulated_offset_ms: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,12 +76,13 @@ pub fn spawn<C: 'static + NtpClock + Send>(
     server_reader: tokio::sync::watch::Receiver<Vec<ServerData>>,
     system_reader: tokio::sync::watch::Receiver<SystemSnapshot>,
     clock: C,
+    update_system_clock: bool,
 ) -> JoinHandle<std::io::Result<()>> {
     let config = config.clone();
     tokio::spawn(
         (async move {
             let result =
-                observer(config, sources_reader, server_reader, system_reader, clock).await;
+                observer(config, sources_reader, server_reader, system_reader, clock, update_system_clock).await;
             if let Err(ref e) = result {
                 warn!("Abnormal termination of the state observer: {e}");
                 warn!("The state observer will not be available");
@@ -96,6 +99,7 @@ async fn observer<C: 'static + NtpClock + Send>(
     server_reader: tokio::sync::watch::Receiver<Vec<ServerData>>,
     system_reader: tokio::sync::watch::Receiver<SystemSnapshot>,
     clock: C,
+    update_system_clock: bool,
 ) -> std::io::Result<()> {
     let start_time = Instant::now();
     let timeout = std::time::Duration::from_millis(500);
@@ -172,6 +176,7 @@ async fn handle_connection(
     server_reader: tokio::sync::watch::Receiver<Vec<ServerData>>,
     system_reader: tokio::sync::watch::Receiver<SystemSnapshot>,
     now: NtpTimestamp,
+    update_system_clock: bool,
 ) -> std::io::Result<()> {
     let observe = ObservableState {
         program: ProgramData::with_dynamics(start_time.elapsed().as_secs_f64(), now),
@@ -183,6 +188,8 @@ async fn handle_connection(
             .collect(),
         system: *system_reader.borrow(),
         servers: server_reader.borrow().iter().map(Into::into).collect(),
+        system_clock_adjustment: update_system_clock,
+        accumulated_offset_ms: None, // TODO: wire through SoftClock when available
     };
 
     super::sockets::write_json(stream, &observe).await?;

--- a/ntpd/src/daemon/observer.rs
+++ b/ntpd/src/daemon/observer.rs
@@ -154,6 +154,7 @@ async fn observer<C: 'static + NtpClock + Send>(
                 server_reader,
                 system_reader,
                 now,
+                update_system_clock,
             )
             .await
         };

--- a/ntpd/src/daemon/observer.rs
+++ b/ntpd/src/daemon/observer.rs
@@ -309,6 +309,7 @@ mod tests {
                 servers_reader,
                 system_reader,
                 TestClock,
+                true,
             )
             .await
             .unwrap();
@@ -386,6 +387,7 @@ mod tests {
                 servers_reader,
                 system_reader,
                 TestClock,
+                true,
             )
             .await
             .unwrap();

--- a/ntpd/src/daemon/server.rs
+++ b/ntpd/src/daemon/server.rs
@@ -13,6 +13,7 @@ use tokio::task::JoinHandle;
 use tracing::{Instrument, Span, debug, instrument, warn};
 
 use super::{config::ServerConfig, util::convert_net_timestamp};
+use super::clock::TrueTimeClock;
 
 // Maximum size of udp packet we handle
 const MAX_PACKET_SIZE: usize = 1024;
@@ -98,18 +99,20 @@ impl<'de> Deserialize<'de> for Counter {
     }
 }
 
-pub struct ServerTask<C: 'static + NtpClock + Send> {
+pub struct ServerTask<C: 'static + NtpClock + TrueTimeClock + Send> {
     config: ServerConfig,
     network_wait_period: std::time::Duration,
     keyset: tokio::sync::watch::Receiver<Arc<KeySet>>,
     server: Server<C>,
+    clock: C,
     stats: ServerStats,
 }
 
-impl<C: 'static + NtpClock + Send> ServerTask<C> {
+impl<C: 'static + NtpClock + TrueTimeClock + Clone + Send> ServerTask<C> {
     #[instrument(level = tracing::Level::ERROR, name = "Ntp Server", skip_all, fields(address = debug(config.listen)))]
     pub fn spawn(
         server: Server<C>,
+        clock: C,
         config: ServerConfig,
         stats: ServerStats,
         keyset: tokio::sync::watch::Receiver<Arc<KeySet>>,
@@ -122,6 +125,7 @@ impl<C: 'static + NtpClock + Send> ServerTask<C> {
                     network_wait_period,
                     keyset,
                     server,
+                    clock,
                     stats,
                 };
 
@@ -173,9 +177,10 @@ impl<C: 'static + NtpClock + Send> ServerTask<C> {
                             ..
                         }) if let Some(timestamp) = timestamp_data.selected_timestamp() => {
                             let mut send_buf = [0u8; MAX_PACKET_SIZE];
+                            let recv_time = self.clock.to_true_time(convert_net_timestamp(timestamp));
                             match self.server.handle(
                                 source_addr.ip(),
-                                convert_net_timestamp(timestamp),
+                                recv_time,
                                 &buf[..length],
                                 &mut send_buf[..length],
                                 &mut self.stats,
@@ -280,6 +285,12 @@ mod tests {
         }
     }
 
+    impl TrueTimeClock for TestClock {
+        fn to_true_time(&self, system_time: NtpTimestamp) -> NtpTimestamp {
+            system_time
+        }
+    }
+
     fn serialize_packet_unencrypted(send_packet: &NtpPacket) -> Vec<u8> {
         let mut buf = vec![0; MAX_PACKET_SIZE];
         let mut cursor = Cursor::new(buf.as_mut_slice());
@@ -304,13 +315,14 @@ mod tests {
 
         let server = Server::new_internal(
             config.clone().into(),
-            clock,
+            clock.clone(),
             server_info,
             keyset.borrow().clone(),
         );
 
         let join = ServerTask::spawn(
             server,
+            clock,
             config,
             ServerStats::default(),
             keyset,

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -18,6 +18,7 @@ use super::{
         nts::NtsSpawner, pool::PoolSpawner, sock::SockSpawner, standard::StandardSpawner,
     },
 };
+use super::clock::TrueTimeClock;
 
 #[cfg(feature = "pps")]
 use super::spawn::pps::PpsSpawner;
@@ -56,23 +57,29 @@ pub struct DaemonChannels {
         reason = "FIXME: System needs a larger refactor to properly receive configuration"
     )
 )]
-pub async fn spawn<Controller: TimeSyncController<Clock = NtpClockWrapper>>(
+pub async fn spawn<C, Controller>(
     synchronization_config: SynchronizationConfig,
     algorithm_config: Controller::AlgorithmConfig,
     source_defaults_config: SourceConfig,
-    clock_config: ClockConfig,
+    clock: C,
+    interface: Option<InterfaceName>,
+    timestamp_mode: TimestampMode,
     source_configs: &[NtpSourceConfig],
     server_configs: &[ServerConfig],
     #[cfg(target_os = "linux")] csptp_server_configs: &[crate::daemon::config::CsptpServerConfig],
     keyset: tokio::sync::watch::Receiver<Arc<KeySet>>,
     #[cfg(target_os = "linux")] csptp_config: CsptpConfig,
-) -> std::io::Result<(JoinHandle<std::io::Result<()>>, DaemonChannels)> {
+) -> std::io::Result<(JoinHandle<std::io::Result<()>>, DaemonChannels)>
+where
+    C: NtpClock + TrueTimeClock + Clone + Send + Sync + 'static,
+    Controller: TimeSyncController<Clock = C>,
+{
     let ip_list = super::local_ip_provider::spawn()?;
 
     let (mut system, channels) = SystemTask::<_, Controller>::new(
-        clock_config.clock,
-        clock_config.interface,
-        clock_config.timestamp_mode,
+        clock,
+        interface,
+        timestamp_mode,
         synchronization_config,
         algorithm_config,
         &keyset,
@@ -190,7 +197,7 @@ struct SystemTask<C: NtpClock, Controller: TimeSyncController<Clock = C>> {
     interface: Option<InterfaceName>,
 }
 
-impl<C: NtpClock + Sync, Controller: TimeSyncController<Clock = C>> SystemTask<C, Controller> {
+impl<C: NtpClock + TrueTimeClock + Sync, Controller: TimeSyncController<Clock = C>> SystemTask<C, Controller> {
     #[expect(clippy::too_many_arguments)]
     fn new(
         clock: C,
@@ -640,6 +647,7 @@ impl<C: NtpClock + Sync, Controller: TimeSyncController<Clock = C>> SystemTask<C
         );
         ServerTask::spawn(
             server,
+            self.clock.clone(),
             config,
             stats,
             self.keyset.clone(),

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -9,8 +9,7 @@ use crate::daemon::{
 
 use super::spawn::nts_pool::NtsPoolSpawner;
 use super::{
-    clock::NtpClockWrapper,
-    config::{ClockConfig, NtpSourceConfig, ServerConfig, TimestampMode},
+    config::{NtpSourceConfig, ServerConfig, TimestampMode},
     ntp_source::{MsgForSystem, SourceChannels, SourceTask},
     server::{ServerStats, ServerTask},
     spawn::{

--- a/ntpd/src/daemon/system.rs
+++ b/ntpd/src/daemon/system.rs
@@ -48,6 +48,16 @@ pub struct DaemonChannels {
     pub system_snapshot_receiver: tokio::sync::watch::Receiver<SystemSnapshot>,
 }
 
+#[allow(clippy::too_many_arguments)]
+pub async fn spawn<C, Controller>(
+    synchronization_config: SynchronizationConfig,
+    // ... rest of args
+) -> std::io::Result<(JoinHandle<()>, DaemonChannels)>
+where
+    C: NtpClock + TrueTimeClock + Clone + Send + Sync + 'static,
+    Controller: TimeSyncController<Clock = C>,
+{
+
 /// Spawn the NTP daemon
 #[cfg_attr(
     target_os = "linux",


### PR DESCRIPTION
addresses issue 2322.  Unclear if developers truly want to add this function, but it was flagged as ok for a PR, so I figured I'd try my hand at it.

tested on Ubuntu 26.04 system on the newest version of ntpd-rs.  I got it to compile with cargo 1.97.1.
I ran it as normal and then with the new flag set to true. I was able to see zero writes using strace using a fake time of 01-01-2020 12:00:00 am. it didn't break it running as normal with the correct time (with the flag `update-system-clock` set as true or omitted), and it was syncing to time servers per usual, so that's a victory in itself.  And when I ran it with the new flag set to false and a fake time (1-1-2020 12:00:00 am) it held that time (and that's when I did the strace writes check).

I added `update-system-clock = bool` (default true) under `[synchronization]` as the issue author suggested.
When set to false:
The daemon never calls `adjtimex`, `clock_adjtime`, `clock_settime`, or `settimeofday` with adjustment flags
The Kalman filter continues to track offset and frequency normally
ServerTask applies the tracked offset to receive timestamps before building NTP responses, so clients still get corrected time
A config warning is emitted on startup if the option is disabled
This allows running ntpd-rs in environments without `CAP_SYS_TIME` while still serving accurate time.

I changed these files-
`ntpd/src/daemon/config/mod.rs` I added config option and validation warning
`ntpd/src/daemon/clock.rs` I added a new SoftClock wrapper and TrueTimeClock trait
`ntpd/src/daemon/server.rs` causes server responses `use to_true_time()`
`ntpd/src/daemon/system.rs` now generic `spawn()` accepts TrueTimeClock bound
`ntpd/src/daemon/observer.rs` this exposes `system_clock_adjustment` in status
`ntpd/src/daemon/mod.rs` this wires SoftClock into main loop