### PR TITLE
Implement handling of additional synchronization data from external sources.

### DIFF
--- a/statime-algo/src/filter.rs
+++ b/statime-algo/src/filter.rs
@@ -1,4 +1,6 @@
-use statime_base::{ClockId, DirectedLinkId, Direction, Duration, LinkId, TAI, Timestamp};
+use statime_base::{
+    ClockId, DirectedLinkId, Direction, Duration, LeapStatus, LinkId, TAI, Timestamp,
+};
 
 use crate::{
     AlgoError,
@@ -35,20 +37,6 @@ impl LinkState {
         }
     }
 
-    /// Get the current noise estimate for the link.
-    ///
-    /// # Errors
-    /// Returns an error if the link is tracked but the noise estimate is not yet available.
-    fn noise_estimate(&self) -> Result<f64, AlgoError> {
-        match self {
-            LinkState::Tracked {
-                link_noise_estimator,
-                ..
-            } => Ok(link_noise_estimator.noise_estimate()?),
-            LinkState::Untracked => Ok(0.0),
-        }
-    }
-
     /// Get the decay rate for the link.
     fn decay_rate(&self) -> f64 {
         match self {
@@ -81,6 +69,9 @@ impl LinkState {
 struct ExternalLinkState {
     last_offsets: UnorderedRingBuffer,
     last_offset_uncertainty: f64,
+    root_delay: f64,
+    leap_status: Option<LeapStatus>,
+    usable: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -107,11 +98,11 @@ pub struct LinkInfo {
 impl LinkInfo {
     /// Get an offset window for the link.
     ///
-    /// Returns None if the link is not with an external clock.
+    /// Returns None if the link is not with an external clock, or if the link is not usable.
     fn offset_window(&self, config: &LinkFilterConfig) -> Option<OffsetWindow> {
         let external_link_state = self.external_link_state.as_ref()?;
 
-        if external_link_state.last_offsets.as_ref().is_empty() {
+        if external_link_state.last_offsets.as_ref().is_empty() || !external_link_state.usable {
             return None;
         }
 
@@ -126,9 +117,11 @@ impl LinkInfo {
             .sum::<f64>()
             / (external_link_state.last_offsets.as_ref().len() as f64);
 
-        let noise_estimate = self.link_state.noise_estimate().ok()?;
-        let half_window_size = noise_estimate * config.select_link_uncertainty_window
-            + external_link_state.last_offset_uncertainty * config.select_offset_uncertainty_window;
+        let LinkDelayNoiseEstimate { delay, noise } =
+            self.link_state.delay_and_noise_estimate().ok()?;
+        let half_window_size = noise * config.select_link_uncertainty_window
+            + external_link_state.last_offset_uncertainty * config.select_offset_uncertainty_window
+            + (delay + external_link_state.root_delay) * config.select_delay_uncertainty_window;
 
         Some(OffsetWindow {
             low: avg_offset - half_window_size,
@@ -212,9 +205,13 @@ pub struct LinkFilterConfig {
     /// offset.
     pub select_offset_uncertainty_window: f64,
     /// Size of the window of uncertainty to assume around source offset for
-    /// judging whether it is a truechimer, based on the observerd link delay
+    /// judging whether it is a truechimer, based on the observed link delay
     /// noise.
     pub select_link_uncertainty_window: f64,
+    /// Size of the window of uncertainty to assume around source offset for
+    /// judging whether it is a truechimer, from potential asymmetry due to
+    /// delay and root delay.
+    pub select_delay_uncertainty_window: f64,
     /// Maximum size of the window of uncertainty before we judge a source to
     /// be unsuitable for synchronization.
     pub select_max_window_size: f64,
@@ -400,6 +397,60 @@ impl<Storage: KalmanStorageBase> LinkFilter<Storage> {
         Ok(self)
     }
 
+    pub fn external_data_update(
+        mut self,
+        link_id: LinkId,
+        root_delay: f64,
+        leap_status: Option<LeapStatus>,
+        usable: bool,
+    ) -> Result<Self, AlgoError> {
+        let link = self.links.find_by_id_mut(link_id)?;
+        if let Some(external_state) = &mut link.external_link_state {
+            external_state.root_delay = root_delay;
+            external_state.leap_status = leap_status;
+            external_state.usable = usable;
+            Ok(self)
+        } else {
+            Err(AlgoError::LinkNotExternal(link_id))
+        }
+    }
+
+    #[expect(unused)]
+    #[must_use]
+    pub fn leap_vote(&self, config: &LinkFilterConfig) -> Option<LeapStatus> {
+        let consensus_window = self.find_external_consensus_window(config)?;
+
+        let mut count_none = 0;
+        let mut count_59 = 0;
+        let mut count_61 = 0;
+
+        for link in self.links.iter() {
+            if let Some(window) = link.offset_window(config)
+                && window.overlaps(consensus_window)
+                && let Some(state) = &link.external_link_state
+            {
+                match state.leap_status {
+                    Some(LeapStatus::None) => count_none += 1,
+                    Some(LeapStatus::Leap59) => count_59 += 1,
+                    Some(LeapStatus::Leap61) => count_61 += 1,
+                    None => { /* no vote */ }
+                }
+            }
+        }
+
+        let total = count_none + count_59 + count_61;
+
+        if count_none * 2 > total {
+            Some(LeapStatus::None)
+        } else if count_59 * 2 > total {
+            Some(LeapStatus::Leap59)
+        } else if count_61 * 2 > total {
+            Some(LeapStatus::Leap61)
+        } else {
+            None
+        }
+    }
+
     /// Add an external clock to the filter.
     ///
     /// # Errors
@@ -499,6 +550,9 @@ impl<Storage: KalmanStorageBase> LinkFilter<Storage> {
                 Some(ExternalLinkState {
                     last_offsets: UnorderedRingBuffer::default(),
                     last_offset_uncertainty: 0.0,
+                    root_delay: 0.0,
+                    leap_status: None,
+                    usable: false,
                 })
             },
         });
@@ -545,6 +599,9 @@ impl<Storage: KalmanStorageBase> LinkFilter<Storage> {
                 Some(ExternalLinkState {
                     last_offsets: UnorderedRingBuffer::default(),
                     last_offset_uncertainty: 0.0,
+                    root_delay: 0.0,
+                    leap_status: None,
+                    usable: false,
                 })
             },
         });

--- a/statime-algo/src/filter.rs
+++ b/statime-algo/src/filter.rs
@@ -415,7 +415,6 @@ impl<Storage: KalmanStorageBase> LinkFilter<Storage> {
         }
     }
 
-    #[expect(unused)]
     #[must_use]
     pub fn leap_vote(&self, config: &LinkFilterConfig) -> Option<LeapStatus> {
         let consensus_window = self.find_external_consensus_window(config)?;
@@ -449,6 +448,24 @@ impl<Storage: KalmanStorageBase> LinkFilter<Storage> {
         } else {
             None
         }
+    }
+
+    #[must_use]
+    pub fn local_root_delay(&self, config: &LinkFilterConfig) -> Option<f64> {
+        let consensus_window = self.find_external_consensus_window(config)?;
+
+        let mut best_delay = f64::MAX;
+        for link in self.links.iter() {
+            if let Some(window) = link.offset_window(config)
+                && window.overlaps(consensus_window)
+                && let Some(state) = &link.external_link_state
+                && let Ok(estimate) = link.link_state.delay_and_noise_estimate()
+            {
+                best_delay = best_delay.min(state.root_delay + estimate.delay);
+            }
+        }
+
+        Some(best_delay)
     }
 
     /// Add an external clock to the filter.

--- a/statime-algo/src/lib.rs
+++ b/statime-algo/src/lib.rs
@@ -93,7 +93,7 @@ impl From<ClockError> for AlgoError {
 }
 
 mod hidden {
-    use statime_base::{Clock, ClockId};
+    use statime_base::{Clock, ClockId, Duration};
 
     use crate::{
         filter::{LinkFilter, LinkFilterConfig},
@@ -110,6 +110,7 @@ mod hidden {
         pub(crate) clocks: Storage::SteeredClockStorage,
         pub(crate) filter: LinkFilter<Storage>,
         pub(crate) filter_config: LinkFilterConfig,
+        pub(crate) root_delay: Duration,
     }
 }
 pub(crate) use hidden::{ClockInfo, KalmanControllerState};
@@ -152,6 +153,7 @@ impl<Storage: KalmanStorage<C>, C: Clock> KalmanController<Storage, C> {
                     clocks,
                     filter,
                     filter_config,
+                    root_delay: Duration::ZERO,
                 }),
             },
             id,
@@ -320,6 +322,12 @@ impl<Storage: KalmanStorageInternal<C>, C: Clock> KalmanControllerState<Storage,
             .filter
             .clone()
             .progress_time(self.clocks[0].clock.now()?)?;
+
+        let leap_status = self.filter.leap_vote(&self.filter_config);
+        if let Some(root_delay) = self.filter.local_root_delay(&self.filter_config) {
+            self.root_delay = Duration::from_f64_seconds(root_delay);
+        }
+
         for (index, clock_info) in self.clocks.iter_mut().enumerate() {
             // FIXME: Make constants configurable.
 
@@ -358,6 +366,17 @@ impl<Storage: KalmanStorageInternal<C>, C: Clock> KalmanControllerState<Storage,
                     filter = filter.absorb_offset_change(clock_info.id, -offset)?;
                 }
             }
+
+            if let Some(leap_status) = leap_status {
+                clock_info.clock.leap_update(leap_status)?;
+            }
+            clock_info
+                .clock
+                .synchronization_update(offset_uncertainty < 1.0)?;
+            clock_info.clock.error_estimate_update(
+                Duration::from_f64_seconds(offset_uncertainty),
+                self.root_delay,
+            )?;
         }
 
         self.filter = filter;

--- a/statime-algo/src/lib.rs
+++ b/statime-algo/src/lib.rs
@@ -29,7 +29,8 @@ mod storage;
 
 use core::marker::PhantomData;
 use statime_base::{
-    Clock, ClockError, ClockId, DirectedLinkId, Direction, Duration, LinkId, TAI, Timestamp,
+    Clock, ClockError, ClockId, DirectedLinkId, Direction, Duration, LeapStatus, LinkId, TAI,
+    Timestamp,
 };
 
 use crate::{
@@ -54,6 +55,8 @@ pub enum AlgoError {
     UnknownLink(LinkId),
     /// Link already exists in the estimator or filter state
     LinkAlreadyExists(LinkId),
+    /// The link does not contain an external clock
+    LinkNotExternal(LinkId),
     /// Measurements or links cannot be between two external clocks
     BothClocksExternal(ClockId, ClockId),
     /// Measurements or links between a clock and itself are not allowed
@@ -422,6 +425,27 @@ impl<ControllerRef: AsRef<KalmanController<Storage, C>>, Storage: KalmanStorage<
             Ok(())
         })
     }
+
+    /// Update additional time keeping information provided by the remote for this link.
+    ///
+    /// # Errors
+    /// Fails if the link does not contain an external clock.
+    pub fn external_data_update(
+        &self,
+        root_delay: Duration,
+        leap_status: Option<LeapStatus>,
+        usable: bool,
+    ) -> Result<(), AlgoError> {
+        self.controller.as_ref().state.with_mut(|state| {
+            state.filter = state.filter.clone().external_data_update(
+                self.link_id,
+                root_delay.as_seconds(),
+                leap_status,
+                usable,
+            )?;
+            Ok(())
+        })
+    }
 }
 
 /// A measurement done on a link.
@@ -433,6 +457,4 @@ pub struct Measurement {
     pub recv_timestamp: Timestamp<TAI>,
     /// The uncertainty of the timestamps.
     pub uncertainty: Duration,
-    /// The delay to UTC of the external clock, if any. Use zero on internal measurements.
-    pub root_delay: Duration,
 }

--- a/statime-algo/src/lib.rs
+++ b/statime-algo/src/lib.rs
@@ -323,9 +323,12 @@ impl<Storage: KalmanStorageInternal<C>, C: Clock> KalmanControllerState<Storage,
         for (index, clock_info) in self.clocks.iter_mut().enumerate() {
             // FIXME: Make constants configurable.
 
-            let offset = self.filter.clock_offset(clock_info.id)?.value;
+            let UncertainValue {
+                value: offset,
+                uncertainty: offset_uncertainty,
+            } = self.filter.clock_offset(clock_info.id)?;
 
-            if offset < 10.0 {
+            if offset < 10.0 && offset > 5.0 * offset_uncertainty {
                 let frequency = self.filter.clock_frequency(clock_info.id)?.value;
 
                 let cur_frequency_steer = clock_info.clock.get_frequency()?;


### PR DESCRIPTION
This handles root_delay and delay and their impact on selection, the leap status voting needed for determining proper leap status updates, and source usability status.

It also implements updating the clocks metadata on these properties during the steering loop.

Closes #2402 and #2403