### PR TITLE
Add missing root toolchain to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
   cooldown:
     default-days: 7
 - package-ecosystem: "rust-toolchain"
-  directories: ["/.rust-toolchain/stable/", "/.rust-toolchain/beta/", "/.rust-toolchain/nightly/"]
+  directories: ["/", "/.rust-toolchain/stable/", "/.rust-toolchain/beta/", "/.rust-toolchain/nightly/"]
   schedule:
     interval: "weekly"
   cooldown:

--- a/.rust-toolchain/beta/rust-toolchain.toml
+++ b/.rust-toolchain/beta/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.98.0-beta.1"
+channel = "beta-2026-08-10"


### PR DESCRIPTION
Also switches beta to the "beta-yyyy-mm-dd" format, because that is the only format dependabot apparently supports.