### PR TITLE
Make clock trait timescale dependent.

### DIFF
--- a/clock-steering/examples/basic.rs
+++ b/clock-steering/examples/basic.rs
@@ -12,20 +12,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let arg = std::env::args().nth(1);
 
     #[cfg(target_os = "linux")]
-    let clock: UnixClock = match arg.as_deref() {
-        None | Some("realtime") => UnixClock::CLOCK_REALTIME,
-        Some("tai") => UnixClock::CLOCK_TAI,
-        Some(path) if path.starts_with("/dev/") => UnixClock::open(path)?,
+    match arg.as_deref() {
+        None | Some("realtime") => exercise_clock(UnixClock::CLOCK_REALTIME),
+        Some("tai") => exercise_clock(UnixClock::CLOCK_TAI),
+        Some(path) if path.starts_with("/dev/") => exercise_clock(UnixClock::open(path)?),
         Some(other) => {
             eprintln!("unknown clock: {other}");
             eprintln!("usage: basic [realtime|tai|/dev/ptpN]");
             std::process::exit(1);
         }
-    };
+    }
 
     #[cfg(not(target_os = "linux"))]
-    let clock = UnixClock::CLOCK_REALTIME;
+    exercise_clock(UnixClock::CLOCK_REALTIME)
+}
 
+fn exercise_clock<Timescale: Send + 'static>(
+    clock: UnixClock<Timescale>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Read-only operations
 
     let now = clock.now()?;

--- a/clock-steering/src/unix.rs
+++ b/clock-steering/src/unix.rs
@@ -1,8 +1,8 @@
-use libc::CLOCK_REALTIME;
-use statime_base::{Clock, ClockError, Duration, LeapStatus, Timestamp, TAI};
+use statime_base::{Clock, ClockError, Duration, LeapStatus, Timestamp, TAI, UTC};
 
 #[cfg(target_os = "linux")]
 use crate::linux_ioctls::{ptp_clock_getcaps, PtpClockCaps};
+use std::marker::PhantomData;
 #[cfg(target_os = "linux")]
 use std::mem::MaybeUninit;
 #[cfg(target_os = "linux")]
@@ -12,14 +12,43 @@ use std::{
 };
 
 /// A Unix OS clock
-#[derive(Debug, Clone, Copy)]
-pub struct UnixClock {
+pub struct UnixClock<Timescale> {
     clock: libc::clockid_t,
     #[cfg(target_os = "linux")]
     fd: Option<RawFd>,
+    _timescale: PhantomData<Timescale>,
 }
 
-impl UnixClock {
+impl<Timescale> std::fmt::Debug for UnixClock<Timescale> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(target_os = "linux")]
+        {
+            f.debug_struct("UnixClock")
+                .field("clock", &self.clock)
+                .field("fd", &self.fd)
+                .field("_timescale", &self._timescale)
+                .finish()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            f.debug_struct("UnixClock")
+                .field("clock", &self.clock)
+                .field("_timescale", &self._timescale)
+                .finish()
+        }
+    }
+}
+
+impl<Timescale> Clone for UnixClock<Timescale> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<Timescale> Copy for UnixClock<Timescale> {}
+
+impl UnixClock<UTC> {
     /// The standard realtime clock on unix systems.
     ///
     /// ```no_run
@@ -37,8 +66,11 @@ impl UnixClock {
         clock: libc::CLOCK_REALTIME,
         #[cfg(target_os = "linux")]
         fd: None,
+        _timescale: PhantomData,
     };
+}
 
+impl UnixClock<TAI> {
     /// TAI time on linux systems.
     ///
     /// ```no_run
@@ -56,6 +88,7 @@ impl UnixClock {
     pub const CLOCK_TAI: Self = UnixClock {
         clock: libc::CLOCK_TAI,
         fd: None,
+        _timescale: PhantomData,
     };
 
     /// Open a clock device.
@@ -97,6 +130,7 @@ impl UnixClock {
         Self {
             clock,
             fd: Some(fd),
+            _timescale: PhantomData,
         }
     }
 
@@ -161,7 +195,9 @@ impl UnixClock {
             ))
         }
     }
+}
 
+impl<Timescale> UnixClock<Timescale> {
     /// Disable any kernel disciplining of this clock.
     ///
     /// # Errors
@@ -294,7 +330,7 @@ impl UnixClock {
         clippy::trivially_copy_pass_by_ref,
         reason = "Allows a consistent interface between platforms."
     )]
-    fn step_clock_by_timespec(&self, offset: Duration) -> Result<Timestamp<TAI>, ClockError> {
+    fn step_clock_by_timespec(&self, offset: Duration) -> Result<Timestamp<Timescale>, ClockError> {
         let steps = offset.as_raw_steps();
         #[cfg_attr(
             target_env = "musl",
@@ -332,11 +368,7 @@ impl UnixClock {
 
         self.clock_settime(timespec)?;
 
-        Ok(current_time_timespec(
-            timespec,
-            Precision::Nano,
-            self.clock == CLOCK_REALTIME,
-        ))
+        Ok(current_time_timespec(timespec, Precision::Nano))
     }
 
     fn error_estimate_timex(esterror: Duration, maxerror: Duration) -> libc::timex {
@@ -385,7 +417,7 @@ impl UnixClock {
     }
 
     #[cfg(target_os = "linux")]
-    fn step_clock_by_timex(&self, offset: Duration) -> Result<Timestamp<TAI>, ClockError> {
+    fn step_clock_by_timex(&self, offset: Duration) -> Result<Timestamp<Timescale>, ClockError> {
         let mut timex = Self::step_clock_timex(offset)?;
         self.adjtime(&mut timex)?;
         self.extract_current_time(&timex)
@@ -398,7 +430,7 @@ impl UnixClock {
     fn extract_current_time(
         &self,
         #[cfg_attr(target_os = "macos", allow(unused))] timex: &libc::timex,
-    ) -> Result<Timestamp<TAI>, ClockError> {
+    ) -> Result<Timestamp<Timescale>, ClockError> {
         #[cfg(target_os = "linux")]
         // hardware clocks may not report the timestamp
         if timex.time.tv_sec != 0 && timex.time.tv_usec != 0 {
@@ -408,20 +440,12 @@ impl UnixClock {
                 _ => Precision::Nano,
             };
 
-            return Ok(current_time_timeval(
-                timex.time,
-                precision,
-                self.clock == CLOCK_REALTIME,
-            ));
+            return Ok(current_time_timeval(timex.time, precision));
         }
 
         // clock_gettime always gives nanoseconds
         let timespec = self.clock_gettime()?;
-        Ok(current_time_timespec(
-            timespec,
-            Precision::Nano,
-            self.clock == CLOCK_REALTIME,
-        ))
+        Ok(current_time_timespec(timespec, Precision::Nano))
     }
 
     #[allow(
@@ -564,9 +588,7 @@ impl UnixClock {
             Duration::from_seconds_nanos(timespec.tv_sec.into(), timespec.tv_nsec as u32)
         })
     }
-}
 
-impl UnixClock {
     #[cfg(target_os = "linux")]
     fn fetch_max_frequency_adjustment(&self) -> Result<f64, ClockError> {
         if let Some(fd) = self.fd {
@@ -602,20 +624,20 @@ impl UnixClock {
     }
 }
 
-impl Clock for UnixClock {
-    fn now(&self) -> Result<Timestamp<TAI>, ClockError> {
+impl<Timescale: Send + 'static> Clock<Timescale> for UnixClock<Timescale> {
+    fn now(&self) -> Result<Timestamp<Timescale>, ClockError> {
         let mut ntp_kapi_timex = EMPTY_TIMEX;
 
         if self.adjtime(&mut ntp_kapi_timex).is_ok() {
             Ok(self.extract_current_time(&ntp_kapi_timex)?)
         } else {
-            Ok(self.clock_gettime().map(|ts| {
-                current_time_timespec(ts, Precision::Nano, self.clock == CLOCK_REALTIME)
-            })?)
+            Ok(self
+                .clock_gettime()
+                .map(|ts| current_time_timespec(ts, Precision::Nano))?)
         }
     }
 
-    fn set_frequency(&self, freq: f64) -> Result<Timestamp<TAI>, ClockError> {
+    fn set_frequency(&self, freq: f64) -> Result<Timestamp<Timescale>, ClockError> {
         let mut timex = Self::set_frequency_timex(freq * 1e6);
         self.adjtime(&mut timex)?;
         self.extract_current_time(&timex)
@@ -641,12 +663,12 @@ impl Clock for UnixClock {
     }
 
     #[cfg(target_os = "linux")]
-    fn step_clock(&self, offset: Duration) -> Result<Timestamp<TAI>, ClockError> {
+    fn step_clock(&self, offset: Duration) -> Result<Timestamp<Timescale>, ClockError> {
         self.step_clock_by_timex(offset)
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn step_clock(&self, offset: Duration) -> Result<Timestamp<TAI>, ClockError> {
+    fn step_clock(&self, offset: Duration) -> Result<Timestamp<Timescale>, ClockError> {
         self.step_clock_by_timespec(offset)
     }
 
@@ -740,12 +762,11 @@ pub(crate) enum Precision {
     clippy::useless_conversion,
     reason = "Conversion is necessary on some platforms."
 )]
-fn current_time_timespec(
+fn current_time_timespec<Timescale>(
     timespec: libc::timespec,
     precision: Precision,
-    is_utc: bool,
-) -> Timestamp<TAI> {
-    let mut seconds = timespec.tv_sec.wrapping_add(if is_utc { 37 } else { 0 });
+) -> Timestamp<Timescale> {
+    let mut seconds = timespec.tv_sec;
 
     let nanos: i32 = timespec.tv_nsec as _;
 
@@ -778,12 +799,11 @@ fn current_time_timespec(
     reason = "tv_usec is always less than 1_000_000_000, which fits in an i32"
 )]
 #[expect(clippy::cast_sign_loss, reason = "tv_usec is guaranteed to be >=0")]
-fn current_time_timeval(
+fn current_time_timeval<Timescale>(
     timespec: libc::timeval,
     precision: Precision,
-    is_utc: bool,
-) -> Timestamp<TAI> {
-    let seconds = timespec.tv_sec.wrapping_add(if is_utc { 37 } else { 0 });
+) -> Timestamp<Timescale> {
+    let seconds = timespec.tv_sec;
     let nanos = match precision {
         Precision::Nano => timespec.tv_usec as u32,
         Precision::Micro => (timespec.tv_usec as u32)
@@ -888,7 +908,7 @@ pub const EMPTY_TIMEX: libc::timex = libc::timex {
 
 #[cfg(test)]
 mod tests {
-    use statime_base::{Clock, Duration, Timestamp};
+    use statime_base::{Clock, Duration, Timestamp, UTC};
 
     use super::UnixClock;
 
@@ -927,7 +947,7 @@ mod tests {
     #[test]
     fn test_step_clock() {
         let offset = Duration::from_seconds_nanos(1, 200_000_000);
-        let timex = UnixClock::step_clock_timex(offset).unwrap();
+        let timex = UnixClock::<UTC>::step_clock_timex(offset).unwrap();
 
         assert_eq!(timex.modes, libc::ADJ_SETOFFSET | libc::ADJ_NANO);
 
@@ -939,7 +959,7 @@ mod tests {
     fn test_error_estimate() {
         let est_error = Duration::from_seconds_nanos(0, 500_000_000);
         let max_error = Duration::from_seconds_nanos(1, 200_000_000);
-        let timex = UnixClock::error_estimate_timex(est_error, max_error);
+        let timex = UnixClock::<UTC>::error_estimate_timex(est_error, max_error);
 
         assert_eq!(timex.modes, libc::MOD_ESTERROR | libc::MOD_MAXERROR);
 

--- a/ntp-proto/src/time_types.rs
+++ b/ntp-proto/src/time_types.rs
@@ -3,7 +3,7 @@ use rand::{
     distributions::{Distribution, Standard},
 };
 use serde::{Deserialize, Serialize, de::Unexpected};
-use statime_base::{TAI, Timestamp};
+use statime_base::{TAI, Timestamp, UTC};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use std::time::Duration;
 
@@ -24,10 +24,23 @@ impl std::fmt::Debug for NtpTimestamp {
 // Epoch offset between NTP and UNIX TAI timescales
 // FIXME: More properly deal with TAI vs UTC
 const EPOCH_OFFSET: statime_base::Duration =
-    statime_base::Duration::from_seconds_nanos((70 * 365 + 17) * 86400 + 37, 0);
+    statime_base::Duration::from_seconds_nanos((70 * 365 + 17) * 86400, 0);
 
 impl From<Timestamp<TAI>> for NtpTimestamp {
     fn from(value: Timestamp<TAI>) -> Self {
+        let steps = (value - Timestamp::UNIX_EPOCH
+            + EPOCH_OFFSET
+            + statime_base::Duration::from_seconds_nanos(37, 0))
+        .as_raw_steps();
+        // We want wrapping here, so cast is fine
+        NtpTimestamp {
+            timestamp: (steps >> 32) as u64,
+        }
+    }
+}
+
+impl From<Timestamp<UTC>> for NtpTimestamp {
+    fn from(value: Timestamp<UTC>) -> Self {
         let steps = (value - Timestamp::UNIX_EPOCH + EPOCH_OFFSET).as_raw_steps();
         // We want wrapping here, so cast is fine
         NtpTimestamp {

--- a/ntpd/src/daemon/clock.rs
+++ b/ntpd/src/daemon/clock.rs
@@ -1,19 +1,31 @@
 use clock_steering::unix::UnixClock;
 use ntp_proto::{NtpClock, NtpTimestamp};
-use statime_base::{Clock, ClockError, Duration, LeapStatus};
+use statime_base::{Clock, ClockError, Duration, LeapStatus, TAI, UTC};
 
 #[derive(Debug, Clone, Copy)]
-pub struct NtpClockWrapper(UnixClock);
+pub struct NtpClockWrapper(NtpClockWrapperInner);
 
-impl NtpClockWrapper {
-    pub fn new(clock: UnixClock) -> Self {
-        NtpClockWrapper(clock)
+#[derive(Debug, Clone, Copy)]
+enum NtpClockWrapperInner {
+    Utc(UnixClock<UTC>),
+    Tai(UnixClock<TAI>),
+}
+
+impl From<UnixClock<TAI>> for NtpClockWrapper {
+    fn from(value: UnixClock<TAI>) -> Self {
+        Self(NtpClockWrapperInner::Tai(value))
+    }
+}
+
+impl From<UnixClock<UTC>> for NtpClockWrapper {
+    fn from(value: UnixClock<UTC>) -> Self {
+        Self(NtpClockWrapperInner::Utc(value))
     }
 }
 
 impl Default for NtpClockWrapper {
     fn default() -> Self {
-        NtpClockWrapper(UnixClock::CLOCK_REALTIME)
+        NtpClockWrapper(NtpClockWrapperInner::Utc(UnixClock::CLOCK_REALTIME))
     }
 }
 
@@ -21,28 +33,49 @@ impl NtpClock for NtpClockWrapper {
     type Error = ClockError;
 
     fn now(&self) -> Result<ntp_proto::NtpTimestamp, Self::Error> {
-        self.0.now().map(NtpTimestamp::from)
+        match self.0 {
+            NtpClockWrapperInner::Utc(unix_clock) => unix_clock.now().map(NtpTimestamp::from),
+            NtpClockWrapperInner::Tai(unix_clock) => unix_clock.now().map(NtpTimestamp::from),
+        }
     }
 
     fn set_frequency(&self, freq: f64) -> Result<ntp_proto::NtpTimestamp, Self::Error> {
-        self.0.set_frequency(freq).map(NtpTimestamp::from)
+        match self.0 {
+            NtpClockWrapperInner::Utc(unix_clock) => {
+                unix_clock.set_frequency(freq).map(NtpTimestamp::from)
+            }
+            NtpClockWrapperInner::Tai(unix_clock) => {
+                unix_clock.set_frequency(freq).map(NtpTimestamp::from)
+            }
+        }
     }
 
     fn get_frequency(&self) -> Result<f64, Self::Error> {
-        self.0.get_frequency()
+        match self.0 {
+            NtpClockWrapperInner::Utc(unix_clock) => unix_clock.get_frequency(),
+            NtpClockWrapperInner::Tai(unix_clock) => unix_clock.get_frequency(),
+        }
     }
 
     fn step_clock(
         &self,
         offset: ntp_proto::NtpDuration,
     ) -> Result<ntp_proto::NtpTimestamp, Self::Error> {
-        self.0
-            .step_clock(Duration::from(offset))
-            .map(NtpTimestamp::from)
+        match self.0 {
+            NtpClockWrapperInner::Utc(unix_clock) => unix_clock
+                .step_clock(Duration::from(offset))
+                .map(NtpTimestamp::from),
+            NtpClockWrapperInner::Tai(unix_clock) => unix_clock
+                .step_clock(Duration::from(offset))
+                .map(NtpTimestamp::from),
+        }
     }
 
     fn disable_ntp_algorithm(&self) -> Result<(), Self::Error> {
-        self.0.disable_kernel()
+        match self.0 {
+            NtpClockWrapperInner::Utc(unix_clock) => unix_clock.disable_kernel(),
+            NtpClockWrapperInner::Tai(unix_clock) => unix_clock.disable_kernel(),
+        }
     }
 
     fn error_estimate_update(
@@ -50,26 +83,52 @@ impl NtpClock for NtpClockWrapper {
         est_error: ntp_proto::NtpDuration,
         max_error: ntp_proto::NtpDuration,
     ) -> Result<(), Self::Error> {
-        self.0
-            .error_estimate_update(est_error.into(), max_error.into())
+        match self.0 {
+            NtpClockWrapperInner::Utc(unix_clock) => {
+                unix_clock.error_estimate_update(est_error.into(), max_error.into())
+            }
+            NtpClockWrapperInner::Tai(unix_clock) => {
+                unix_clock.error_estimate_update(est_error.into(), max_error.into())
+            }
+        }
     }
 
     fn status_update(&self, leap_status: ntp_proto::NtpLeapIndicator) -> Result<(), Self::Error> {
         match leap_status {
             ntp_proto::NtpLeapIndicator::NoWarning => {
-                self.0.synchronization_update(true)?;
-                self.0.leap_update(LeapStatus::None)
+                self.synchronization_update(true)?;
+                self.leap_update(LeapStatus::None)
             }
             ntp_proto::NtpLeapIndicator::Leap61 => {
-                self.0.synchronization_update(true)?;
-                self.0.leap_update(LeapStatus::Leap61)
+                self.synchronization_update(true)?;
+                self.leap_update(LeapStatus::Leap61)
             }
             ntp_proto::NtpLeapIndicator::Leap59 => {
-                self.0.synchronization_update(true)?;
-                self.0.leap_update(LeapStatus::Leap59)
+                self.synchronization_update(true)?;
+                self.leap_update(LeapStatus::Leap59)
             }
-            ntp_proto::NtpLeapIndicator::Unknown => self.0.synchronization_update(true),
-            ntp_proto::NtpLeapIndicator::Unsynchronized => self.0.synchronization_update(false),
+            ntp_proto::NtpLeapIndicator::Unknown => self.synchronization_update(true),
+            ntp_proto::NtpLeapIndicator::Unsynchronized => self.synchronization_update(false),
+        }
+    }
+}
+
+impl NtpClockWrapper {
+    fn synchronization_update(self, synchronized: bool) -> Result<(), ClockError> {
+        match self.0 {
+            NtpClockWrapperInner::Utc(unix_clock) => {
+                unix_clock.synchronization_update(synchronized)
+            }
+            NtpClockWrapperInner::Tai(unix_clock) => {
+                unix_clock.synchronization_update(synchronized)
+            }
+        }
+    }
+
+    fn leap_update(self, leap_status: LeapStatus) -> Result<(), ClockError> {
+        match self.0 {
+            NtpClockWrapperInner::Utc(unix_clock) => unix_clock.leap_update(leap_status),
+            NtpClockWrapperInner::Tai(unix_clock) => unix_clock.leap_update(leap_status),
         }
     }
 }

--- a/ntpd/src/daemon/config/mod.rs
+++ b/ntpd/src/daemon/config/mod.rs
@@ -221,12 +221,12 @@ where
         panic!("Custom clock paths not supported on this platform");
 
         #[cfg(target_os = "linux")]
-        Ok(NtpClockWrapper::new(
+        Ok(NtpClockWrapper::from(
             UnixClock::open(path).map_err(|e| serde::de::Error::custom(e.to_string()))?,
         ))
     } else {
         tracing::debug!("using REALTIME clock");
-        Ok(NtpClockWrapper::new(UnixClock::CLOCK_REALTIME))
+        Ok(NtpClockWrapper::from(UnixClock::CLOCK_REALTIME))
     }
 }
 

--- a/statime-algo/src/lib.rs
+++ b/statime-algo/src/lib.rs
@@ -144,7 +144,7 @@ impl Default for ClockConfig {
 }
 
 mod hidden {
-    use statime_base::{Clock, ClockId, Duration, LeapStatus};
+    use statime_base::{Clock, ClockId, Duration, LeapStatus, TAI};
 
     use crate::{
         ClockConfig,
@@ -159,7 +159,7 @@ mod hidden {
     }
 
     /// The main controller struct.
-    pub struct KalmanControllerState<Storage: KalmanStorageInternal<C>, C: Clock> {
+    pub struct KalmanControllerState<Storage: KalmanStorageInternal<C>, C: Clock<TAI>> {
         pub(crate) clocks: Storage::SteeredClockStorage,
         pub(crate) filter: LinkFilter<Storage>,
         pub(crate) filter_config: ControllerConfig,
@@ -170,11 +170,11 @@ mod hidden {
 pub(crate) use hidden::{ClockInfo, KalmanControllerState};
 
 /// Controller for clocks using a kalman filter as its state estimation mechanism.
-pub struct KalmanController<Storage: KalmanStorage<C>, C: Clock> {
+pub struct KalmanController<Storage: KalmanStorage<C>, C: Clock<TAI>> {
     state: Storage::StateMutex,
 }
 
-impl<Storage: KalmanStorage<C>, C: Clock> Controller for KalmanController<Storage, C> {
+impl<Storage: KalmanStorage<C>, C: Clock<TAI>> Controller for KalmanController<Storage, C> {
     type Clock = C;
     type Link<ControllerRef: AsRef<Self>> = KalmanLink<ControllerRef, Storage, C>;
     type Error = AlgoError;
@@ -314,7 +314,7 @@ impl<Storage: KalmanStorage<C>, C: Clock> Controller for KalmanController<Storag
     }
 }
 
-impl<Storage: KalmanStorage<C>, C: Clock> KalmanController<Storage, C> {
+impl<Storage: KalmanStorage<C>, C: Clock<TAI>> KalmanController<Storage, C> {
     /// Create a new clock controller
     ///
     /// # Errors
@@ -375,7 +375,7 @@ impl<Storage: KalmanStorage<C>, C: Clock> KalmanController<Storage, C> {
     }
 }
 
-impl<Storage: KalmanStorageInternal<C>, C: Clock> KalmanControllerState<Storage, C> {
+impl<Storage: KalmanStorageInternal<C>, C: Clock<TAI>> KalmanControllerState<Storage, C> {
     fn steer_clocks(&mut self) -> Result<(), AlgoError> {
         let mut filter = self
             .filter
@@ -450,7 +450,7 @@ impl<Storage: KalmanStorageInternal<C>, C: Clock> KalmanControllerState<Storage,
 pub struct KalmanLink<
     ControllerRef: AsRef<KalmanController<Storage, C>>,
     Storage: KalmanStorage<C>,
-    C: Clock,
+    C: Clock<TAI>,
 > {
     link_id: LinkId,
     // We use a generic reference to the kalman controller here to avoid
@@ -462,8 +462,8 @@ pub struct KalmanLink<
     phantomdata: PhantomData<(Storage, C)>,
 }
 
-impl<ControllerRef: AsRef<KalmanController<Storage, C>>, Storage: KalmanStorage<C>, C: Clock> Drop
-    for KalmanLink<ControllerRef, Storage, C>
+impl<ControllerRef: AsRef<KalmanController<Storage, C>>, Storage: KalmanStorage<C>, C: Clock<TAI>>
+    Drop for KalmanLink<ControllerRef, Storage, C>
 {
     fn drop(&mut self) {
         self.controller.as_ref().state.with_mut(|state| {
@@ -477,8 +477,8 @@ impl<ControllerRef: AsRef<KalmanController<Storage, C>>, Storage: KalmanStorage<
     }
 }
 
-impl<ControllerRef: AsRef<KalmanController<Storage, C>>, Storage: KalmanStorage<C>, C: Clock> Link
-    for KalmanLink<ControllerRef, Storage, C>
+impl<ControllerRef: AsRef<KalmanController<Storage, C>>, Storage: KalmanStorage<C>, C: Clock<TAI>>
+    Link for KalmanLink<ControllerRef, Storage, C>
 {
     type Error = AlgoError;
 

--- a/statime-algo/src/storage.rs
+++ b/statime-algo/src/storage.rs
@@ -6,17 +6,17 @@ use core::{
 };
 
 use arrayvec::ArrayVec;
-use statime_base::{Clock, ClockId};
+use statime_base::{Clock, ClockId, TAI};
 
 use crate::KalmanControllerState;
 use crate::filter::BoundType;
 
 /// Storage provider for a [`KalmanController`](crate::KalmanController)
-pub trait KalmanStorage<C: Clock>: KalmanStorageInternal<C> {}
+pub trait KalmanStorage<C: Clock<TAI>>: KalmanStorageInternal<C> {}
 
 /// Internal variant of the storage trait, used to make sure [`KalmanStorage`] is not
 /// implementable externally.
-pub trait KalmanStorageInternal<C: Clock>: KalmanStorageBase {
+pub trait KalmanStorageInternal<C: Clock<TAI>>: KalmanStorageBase {
     type SteeredClockStorage: SteeredClockStorage<C>;
     type StateMutex: StateMutex<Self, C>;
 }
@@ -62,13 +62,13 @@ impl<C> KalmanStorageBase for StdKalmanStorage<C> {
 }
 
 #[cfg(feature = "std")]
-impl<C: Clock> KalmanStorageInternal<C> for StdKalmanStorage<C> {
+impl<C: Clock<TAI>> KalmanStorageInternal<C> for StdKalmanStorage<C> {
     type SteeredClockStorage = std::vec::Vec<crate::ClockInfo<C>>;
     type StateMutex = std::sync::RwLock<crate::KalmanControllerState<StdKalmanStorage<C>, C>>;
 }
 
 #[cfg(feature = "std")]
-impl<C: Clock> KalmanStorage<C> for StdKalmanStorage<C> {}
+impl<C: Clock<TAI>> KalmanStorage<C> for StdKalmanStorage<C> {}
 
 /// Storage for the [`KalmanController`](crate::KalmanController) backed by fixed buffers.
 ///
@@ -101,12 +101,12 @@ impl<C, const N: usize> KalmanStorageBase for NoAllocKalmanStorage<C, N> {
     type BoundStorage = ArrayVec<(f64, crate::filter::BoundType), N>;
 }
 
-impl<C: Clock, const N: usize> KalmanStorageInternal<C> for NoAllocKalmanStorage<C, N> {
+impl<C: Clock<TAI>, const N: usize> KalmanStorageInternal<C> for NoAllocKalmanStorage<C, N> {
     type SteeredClockStorage = ArrayVec<crate::ClockInfo<C>, N>;
     type StateMutex = RefCell<KalmanControllerState<NoAllocKalmanStorage<C, N>, C>>;
 }
 
-impl<C: Clock, const N: usize> KalmanStorage<C> for NoAllocKalmanStorage<C, N> {}
+impl<C: Clock<TAI>, const N: usize> KalmanStorage<C> for NoAllocKalmanStorage<C, N> {}
 
 /// A storage provider for a matrix. Abstracts a dynamically sized array of f64.
 ///
@@ -331,7 +331,7 @@ impl<C, const N: usize> SteeredClockStorage<C> for ArrayVec<crate::ClockInfo<C>,
 }
 
 /// Trait for state management
-pub trait StateMutex<Storage: KalmanStorageInternal<C>, C: Clock> {
+pub trait StateMutex<Storage: KalmanStorageInternal<C>, C: Clock<TAI>> {
     /// Creates a new instance of the mutex
     fn new(state: KalmanControllerState<Storage, C>) -> Self;
 
@@ -343,7 +343,7 @@ pub trait StateMutex<Storage: KalmanStorageInternal<C>, C: Clock> {
 }
 
 #[cfg(feature = "std")]
-impl<Storage: KalmanStorageInternal<C>, C: Clock> StateMutex<Storage, C>
+impl<Storage: KalmanStorageInternal<C>, C: Clock<TAI>> StateMutex<Storage, C>
     for std::sync::RwLock<KalmanControllerState<Storage, C>>
 {
     fn new(state: KalmanControllerState<Storage, C>) -> Self {
@@ -359,7 +359,7 @@ impl<Storage: KalmanStorageInternal<C>, C: Clock> StateMutex<Storage, C>
     }
 }
 
-impl<Storage: KalmanStorageInternal<C>, C: Clock> StateMutex<Storage, C>
+impl<Storage: KalmanStorageInternal<C>, C: Clock<TAI>> StateMutex<Storage, C>
     for RefCell<KalmanControllerState<Storage, C>>
 {
     fn new(state: KalmanControllerState<Storage, C>) -> Self {

--- a/statime-base/src/algorithm.rs
+++ b/statime-base/src/algorithm.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// A controller for clocks in a system.
 pub trait Controller {
     /// Type of clocks which are managed by this controller
-    type Clock: Clock;
+    type Clock: Clock<TAI>;
     /// Measurement links between clocks belonging to the controller.
     type Link<ControllerRef: AsRef<Self>>: Link<Error = Self::Error>;
     /// Errors returned by the controller

--- a/statime-base/src/clock.rs
+++ b/statime-base/src/clock.rs
@@ -1,4 +1,4 @@
-use crate::{Duration, TAI, Timestamp};
+use crate::{Duration, Timestamp};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -43,12 +43,12 @@ impl core::error::Error for ClockError {}
 /// Interface for a controllable clock
 /// This needs to be a trait as a single system can have multiple clocks
 /// which need different implementation for steering and/or now.
-pub trait Clock: Clone + Send + 'static {
+pub trait Clock<Timescale>: Clone + Send + 'static {
     /// Get current time
     ///
     /// # Errors
     /// Should return an error if the clock is unable to provide a timestamp.
-    fn now(&self) -> Result<Timestamp<TAI>, ClockError>;
+    fn now(&self) -> Result<Timestamp<Timescale>, ClockError>;
 
     /// Change the frequency of the clock, returning the time
     /// at which the change was applied. The frequency is
@@ -56,7 +56,7 @@ pub trait Clock: Clone + Send + 'static {
     ///
     /// # Errors
     /// Should return an error if the clock is unable to be steered by the requested amount.
-    fn set_frequency(&self, freq: f64) -> Result<Timestamp<TAI>, ClockError>;
+    fn set_frequency(&self, freq: f64) -> Result<Timestamp<Timescale>, ClockError>;
 
     /// Get the frequency of the clock, in seconds per second deviation
     ///
@@ -75,7 +75,7 @@ pub trait Clock: Clone + Send + 'static {
     ///
     /// # Errors
     /// Should return an error if the clock cannot be stepped by the amount requested.
-    fn step_clock(&self, offset: Duration) -> Result<Timestamp<TAI>, ClockError>;
+    fn step_clock(&self, offset: Duration) -> Result<Timestamp<Timescale>, ClockError>;
 
     /// Provide the system with our current best estimates for
     /// the statistical error of the clock (`est_error`), and


### PR DESCRIPTION
This allows us to better deal with the fact that some clocks are natively UTC, whilst others natively provide TAI. Making each clock able to operate on its native timescale, the conversion logic can be centralized in the ntpd crate.