### PR TITLE
statime-wire: accept a zero-length TLV as the last TLV in a suffix

### DIFF
--- a/statime-wire/src/common/tlv.rs
+++ b/statime-wire/src/common/tlv.rs
@@ -71,7 +71,7 @@ impl<'a> TlvSet<'a> {
         let original = buffer;
         let mut total_length = 0;
 
-        while buffer.len() > 4 {
+        while buffer.len() >= 4 {
             let _tlv_type = TlvType::from_primitive(u16::from_be_bytes([buffer[0], buffer[1]]));
             let length = u16::from_be_bytes([buffer[2], buffer[3]]) as usize;
 
@@ -114,7 +114,7 @@ impl<'a> Iterator for TlvSetIterator<'a> {
     type Item = Tlv<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.buffer.len() <= 4 {
+        if self.buffer.len() < 4 {
             debug_assert_eq!(self.buffer.len(), 0);
             return None;
         }
@@ -416,6 +416,76 @@ mod tests {
 
         assert_eq!(it.next(), Some(tlv2));
         assert_eq!(it.next(), Some(tlv3));
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn parse_trailing_zero_length_tlv() {
+        let mut alloc = [0; 64];
+
+        let tlv1 = Tlv {
+            tlv_type: TlvType::PathTrace,
+            value: (&b"ab"[..]).into(),
+        };
+        let tlv2 = Tlv {
+            tlv_type: TlvType::Experimental(0x2004),
+            value: (&[][..]).into(),
+        };
+
+        tlv1.serialize(&mut alloc).unwrap();
+        tlv2.serialize(&mut alloc[tlv1.wire_size()..]).unwrap();
+
+        let buffer = &alloc[..tlv1.wire_size() + tlv2.wire_size()];
+        let tlv_set = TlvSet::deserialize(buffer).unwrap();
+
+        assert_eq!(tlv_set.wire_size(), buffer.len());
+
+        let mut it = tlv_set.tlvs();
+        assert_eq!(it.next(), Some(tlv1));
+        assert_eq!(it.next(), Some(tlv2));
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn parse_lone_zero_length_tlv() {
+        let tlv = Tlv {
+            tlv_type: TlvType::Experimental(0x2004),
+            value: (&[][..]).into(),
+        };
+
+        let mut alloc = [0; 64];
+        tlv.serialize(&mut alloc).unwrap();
+
+        let buffer = &alloc[..tlv.wire_size()];
+        let tlv_set = TlvSet::deserialize(buffer).unwrap();
+
+        assert_eq!(tlv_set.wire_size(), 4);
+
+        let mut it = tlv_set.tlvs();
+        assert_eq!(it.next(), Some(tlv));
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn iterate_built_set_ending_in_zero_length_tlv() {
+        let tlv1 = Tlv {
+            tlv_type: TlvType::PathTrace,
+            value: (&b"ab"[..]).into(),
+        };
+        let tlv2 = Tlv {
+            tlv_type: TlvType::Experimental(0x2004),
+            value: (&[][..]).into(),
+        };
+
+        let mut alloc = [0; 64];
+        let mut builder = TlvSetBuilder::new(&mut alloc);
+        builder.add(&tlv1).unwrap();
+        builder.add(&tlv2).unwrap();
+        let tlv_set = builder.build();
+
+        let mut it = tlv_set.tlvs();
+        assert_eq!(it.next(), Some(tlv1));
+        assert_eq!(it.next(), Some(tlv2));
         assert_eq!(it.next(), None);
     }
 }


### PR DESCRIPTION
`TlvSet::deserialize` loops `while buffer.len() > 4`. A TLV whose lengthField is 0 occupies exactly 4 bytes, so when it is the last one in the suffix the loop exits with those 4 bytes still unconsumed and the `if !buffer.is_empty()` check rejects the whole message as `BufferTooShort`.

The same zero-length TLV parses fine when it is *not* last, which is what made me look: with two TLVs of value length 0 and 2, `[0, 2]` parses and `[2, 0]` does not.

`TlvSetIterator::next` has the matching off-by-one (`<= 4`). Sets that come out of the parser can never hit it, but sets built with the public `TlvSetBuilder` can, and then the iterator's own `debug_assert_eq!(self.buffer.len(), 0)` fires. So you can build a `TlvSet`, serialize it into a message, and be unable to iterate it or parse it back.

Oracle for the loop bound is linuxptp, which walks the suffix with `while (len >= sizeof(struct TLV))` in `suffix_post_recv` (msg.c) and only rejects on `length % 2`. lengthField 0 is even, so linuxptp accepts these.

Counts, from a generator that builds PTP messages with well-formed TLV suffixes and checks parse -> serialize -> parse:

- suffix ending in a zero-length TLV: 0/70068 round trip before, 43262/70068 after
- suffix ending in a non-empty TLV: 80131/129932 both before and after, unchanged

(the remainder in both rows fail on unrelated random header/body fields)

Fix is `>= 4` in the parser and `< 4` in the iterator. Three tests added; they fail on current main and pass with the two-line change. Rest of `cargo test --workspace --all-features` is unchanged — `ntpd::ctl::test_status` already fails on main here.

AI assistance disclosure: I used an LLM to help drive the differential harness and draft the tests. The diff is two characters of behaviour change and I checked it against linuxptp and the TLV format myself.
