### PR TITLE
Add strict systemd service files

### DIFF
--- a/docs/examples/conf/ntpd-rs-metrics.service
+++ b/docs/examples/conf/ntpd-rs-metrics.service
@@ -7,7 +7,6 @@ Type=notify
 Restart=always
 ExecStart=/usr/bin/ntp-metrics-exporter
 Environment="RUST_LOG=info"
-RuntimeDirectory=ntpd-rs-observe
 User=ntpd-rs-observe
 Group=ntpd-rs-observe
 

--- a/docs/examples/conf/ntpd-rs-metrics.strict.service
+++ b/docs/examples/conf/ntpd-rs-metrics.strict.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=Network Time Service (ntpd-rs) metrics exporter
+Documentation=https://github.com/pendulum-project/ntpd-rs
+
+[Service]
+Type=notify
+Restart=always
+ExecStart=/usr/bin/ntp-metrics-exporter
+Environment="RUST_LOG=info"
+User=ntpd-rs-observe
+Group=ntpd-rs-observe
+
+NoNewPrivileges=yes
+AmbientCapabilities=
+CapabilityBoundingSet=
+
+## No access to any /dev
+DevicePolicy=closed
+PrivateDevices=yes
+
+## Standard minimal systemd lockdown
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_INET AF_INET6
+RemoveIPC=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@basic-io @file-system @io-event @network-io @signal ioctl
+UMask=0000
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/examples/conf/ntpd-rs.strict.service
+++ b/docs/examples/conf/ntpd-rs.strict.service
@@ -1,0 +1,72 @@
+[Unit]
+Description=Network Time Service (ntpd-rs)
+Documentation=https://github.com/pendulum-project/ntpd-rs
+After=network-online.target
+Wants=network-online.target
+Conflicts=systemd-timesyncd.service ntp.service chrony.service
+
+[Service]
+Type=notify
+Restart=no
+ExecStart=/usr/bin/ntp-daemon
+Environment="RUST_LOG=info"
+User=ntpd-rs
+Group=ntpd-rs
+
+NoNewPrivileges=yes
+AmbientCapabilities=CAP_SYS_TIME
+CapabilityBoundingSet=CAP_SYS_TIME
+
+## Sockets live in the runtime directory
+RuntimeDirectory=ntpd-rs
+RuntimeDirectoryMode=0755
+
+## Configuration directory is read by both ntpd-rs and ntpd-rs-metrics
+## No keys should be stored here
+ConfigurationDirectory=ntpd-rs
+ConfigurationDirectoryMode=0555
+
+## (optional) When running as server
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+## (optional) When preserving NTS key materials storage
+## Requires setting state in /var/lib/ntpd-rs subfolder
+StateDirectory=ntpd-rs
+StateDirectoryMode=0700
+
+## Device management
+### (optional) When using PPS
+# DevicePolicy=closed
+# DeviceAllow=/dev/pps
+
+### (default) No access to any /dev
+DevicePolicy=closed
+PrivateDevices=yes
+
+## Standard minimal systemd lockdown
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_INET AF_INET6
+RemoveIPC=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@basic-io @clock @file-system @io-event @network-io @process @signal ioctl madvise
+UMask=0077
+
+## (do not use) This breaks setting the time.
+# PrivateUsers=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds systemd service files which are more restrictive.

(also remove RuntimeDirectory from non-restrictive ntp-metrics-exporter as it serves no purpose there)

With this configuration:
* the entire filesystem is mounted read-only, with exception of the Runtime, State and tmp directories.
* a minimal set of syscalls is allowed.
* a minimal set of networking can occur.
* a minimal set of kernel features are accessible.

Notably what this configuration does not do:
* sandbox and thus make the entire filesystem inaccessible.
* set limits on CPU usage, RAM usage, or disk usage to prevent a Denial of Service.

# Testing
The following features have been tested:
* ntpd server access
* ntp-cli status access
* updating host time
* metrics exporter
* NTS certificates (with certbot)
* NTS key storage

The following features have **not** been tested:
* PPS
* gpsd

# Explanation
A short summary of what is meant by a subset of the lines:
* `NoNewPrivileges=yes` prevents new priviliges through `execve`
* `DevicePolicy=closed` disallows access to any devices except those whitelisted using `DeviceAllow` (and pseudo devices like `/dev/urandom`)
* `PrivateDevices=yes` in addition hides all devices (except pseudo devices)
* `DeviceAllow=` allows access to additional devices, but can not be used in conjunction with `PrivateDevices=`
* `RestrictAddressFamilies=AF_NETLINK` refers to User-space to Kernel communication which is used by some libc functions.
* `SystemCallFilter=` blocks any syscall except those listed there. The list there is achieved using a combination of simple reasoning and trying to run ntpd-rs until it works. As some intermediate libraries such as tokio and std are used to integrate with the OS (as opposed to only using specific syscalls directly in the project), this list is somewhat fragile.
* `UMask=` limits the permissions of any files, directories or sockets made by ntpd-rs.

# Additional work
## Dynamic Users
We can consider also employing [DynamicUser=](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#DynamicUser=) to dynamically assign a new user at every boot. However it is adviseable to then also think up a recommended method of getting renewed certificates to ntpd-rs for NTS using for example [LoadCredential=](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#LoadCredential=ID:PATH).

## Hide the filesystem
We can hide the entire filesystem by overlay the root directory using [TemporaryFileSystem=](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#TemporaryFileSystem=) and bring back our binary dependencies using [BindPaths=](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#BindPaths=).